### PR TITLE
Add ability to unwrap using `tophu`

### DIFF
--- a/.github/workflows/test-build-push.yml
+++ b/.github/workflows/test-build-push.yml
@@ -16,8 +16,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         deps:
+            # Note: for now we're manually adding tophu deps,
+            # will change once it's on conda forge
           - label: Latest
-            spec: ""
+            spec: >-
+              dask
+              rasterio
           - label: Minimum
             spec: >-
               python=3.8
@@ -34,6 +38,8 @@ jobs:
               scipy=1.5
               shapely=1.8
               threadpoolctl>=3.0
+              dask
+              rasterio
         exclude:  # TODO: Remove this once pymp is gone
           - os: macos-latest
             deps:
@@ -63,6 +69,7 @@ jobs:
       - name: Install test dependencies
         run: |
           micromamba install -f tests/requirements.txt -c conda-forge
+          pip install --no-deps git+https://github.com/isce-framework/tophu@main
       - name: Disable numba boundscheck for better error catching
         run: |
           echo "NUMBA_BOUNDSCHECK=1" >> $GITHUB_ENV

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         additional_dependencies:
         - types-pkg_resources
         - types-requests
-        - "pydantic>=2.1"
+        - "pydantic>=2.4"
 
   - repo: https://github.com/PyCQA/pydocstyle
     rev: "6.3.0"

--- a/src/dolphin/_cli_unwrap.py
+++ b/src/dolphin/_cli_unwrap.py
@@ -67,14 +67,28 @@ def get_parser(subparser=None, subcommand_name="unwrap") -> argparse.ArgumentPar
         default=1,
         help="Number of parallel files to unwrap",
     )
-    # Add ability for downsampling/running only coarse_unwrap
-    parser.add_argument(
+
+    tophu_opts = parser.add_argument_group("Tophu options")
+    # Add ability for downsampling/tiling with tophu
+    tophu_opts.add_argument(
+        "--ntiles",
+        type=int,
+        nargs=2,
+        metavar=("ROW_TILES", "COL_TILES"),
+        default=(1, 1),
+        help=(
+            "(using tophu) Split the interferograms into this number of tiles along the"
+            " (row, col) axis."
+        ),
+    )
+    tophu_opts.add_argument(
         "--downsample-factor",
         type=int,
-        default=1,
+        nargs=2,
+        default=(1, 1),
         help=(
-            "Running coarse_unwrap: Downsample the interferograms by this factor to"
-            " unwrap faster."
+            "(using tophu) Downsample the interferograms by this factor "
+            " during multiresolution unwrapping."
         ),
     )
     parser.set_defaults(run_func=_run_unwrap)

--- a/src/dolphin/interferogram.py
+++ b/src/dolphin/interferogram.py
@@ -9,13 +9,7 @@ from typing import Iterable, Literal, Optional, Sequence, Union
 import numpy as np
 from numpy.typing import ArrayLike
 from osgeo import gdal
-from pydantic import (
-    BaseModel,
-    Field,
-    FieldValidationInfo,
-    field_validator,
-    model_validator,
-)
+from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
 from dolphin import io, utils
 from dolphin._log import get_log
@@ -104,7 +98,7 @@ class VRTInterferogram(BaseModel, extra="allow"):
 
     @field_validator("ref_slc", "sec_slc")
     @classmethod
-    def _check_gdal_string(cls, v: Union[Path, str], info: FieldValidationInfo):
+    def _check_gdal_string(cls, v: Union[Path, str], info: ValidationInfo):
         subdataset = info.data.get("subdataset")
         # If we're using a subdataset, create a the GDAL-readable string
         gdal_str = io.format_nc_filename(v, subdataset)
@@ -126,7 +120,7 @@ class VRTInterferogram(BaseModel, extra="allow"):
 
     @field_validator("outdir")
     @classmethod
-    def _check_output_dir(cls, v, info: FieldValidationInfo):
+    def _check_output_dir(cls, v, info: ValidationInfo):
         if v is not None:
             return Path(v)
         # If outdir is not set, use the directory of the reference SLC

--- a/src/dolphin/workflows/_utils.py
+++ b/src/dolphin/workflows/_utils.py
@@ -140,7 +140,7 @@ def make_nodata_mask(
     buffer_pixels: int = 0,
     overwrite: bool = False,
 ):
-    """Make a dummy raster from the first file in the list.
+    """Make a boolean raster mask from the union of nodata polygons.
 
     Parameters
     ----------

--- a/src/dolphin/workflows/config.py
+++ b/src/dolphin/workflows/config.py
@@ -167,10 +167,18 @@ class UnwrapOptions(BaseModel, extra="forbid"):
     )
     _directory: Path = PrivateAttr(Path("unwrapped"))
     unwrap_method: UnwrapMethod = UnwrapMethod.SNAPHU
-    tiles: List[int] = Field(
+    ntiles: List[int] = Field(
         [1, 1],
         description=(
-            "Number of tiles to split the unwrapping into (for multi-scale unwrapping)."
+            "(for multiscale unwrapping) Number of tiles to split the unwrapping into"
+            " (for multi-scale unwrapping)."
+        ),
+    )
+    downsample_factor: List[int] = Field(
+        [1, 1],
+        description=(
+            "(for multiscale unwrapping) Extra multilook factor to use for the coarse"
+            " unwrap."
         ),
     )
     init_method: str = Field(

--- a/src/dolphin/workflows/stitch_and_unwrap.py
+++ b/src/dolphin/workflows/stitch_and_unwrap.py
@@ -139,7 +139,8 @@ def run(
         nlooks=nlooks,
         mask_file=output_mask,
         max_jobs=unwrap_jobs,
-        no_tile=True,
+        ntiles=cfg.unwrap_options.ntiles,
+        downsample_factor=cfg.unwrap_options.downsample_factor,
         use_icu=use_icu,
     )
 

--- a/tests/test_workflows_config.py
+++ b/tests/test_workflows_config.py
@@ -77,9 +77,10 @@ def test_interferogram_network_types():
 def test_unwrap_options_defaults():
     opts = config.UnwrapOptions()
     assert opts.unwrap_method == config.UnwrapMethod.SNAPHU
-    assert opts.tiles == [1, 1]
     assert opts.init_method == "mcf"
     assert opts._directory == Path("unwrapped")
+    assert opts.ntiles == [1, 1]
+    assert opts.downsample_factor == [1, 1]
 
 
 def test_outputs_defaults():


### PR DESCRIPTION
- Finally addresses #10 
- Also removes coarse_unwrap, which is subsumed by this.
- TBD: 
  - how to handle tophu as an optional/mandatory dependency. It uses dask + rasterio. Neither of these are required right now, even though I've considered switching certain things to it (and code could be cut if I fully committed to `rasterio`)
  - number of `tophu` options to expose in the `Workflow`, especially if I have it as an optional dep.

