### PR TITLE
Return ps mask, use `scratchdir` for tophu unwrapping

### DIFF
--- a/.github/workflows/test-build-push.yml
+++ b/.github/workflows/test-build-push.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           micromamba install -f tests/requirements.txt -c conda-forge
           pip install --no-deps git+https://github.com/isce-framework/tophu@main
-      - name: Disable numba boundscheck for better error catching
+      - name: Enable numba boundscheck for better error catching
         run: |
           echo "NUMBA_BOUNDSCHECK=1" >> $GITHUB_ENV
       - name: Test (with numba boundscheck on)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Unreleased](https://github.com/isce-framework/dolphin/compare/v0.5.0...main)
 
+**Added**
+- `stitch_and_unwrap.run` returns the stitch PS mask
 
 # [v0.5.0](https://github.com/isce-framework/dolphin/compare/v0.4.3...v0.5.0)
 

--- a/src/dolphin/unwrap.py
+++ b/src/dolphin/unwrap.py
@@ -40,6 +40,7 @@ def run(
     max_jobs: int = 1,
     ntiles: Union[int, tuple[int, int]] = 1,
     downsample_factor: Union[int, tuple[int, int]] = 1,
+    scratchdir: Optional[Filename] = None,
     overwrite: bool = False,
     **kwargs,
 ) -> tuple[list[Path], list[Path]]:
@@ -74,6 +75,9 @@ def run(
     downsample_factor : int, optional, default = 1
         (For running coarse_unwrap): Downsample the interferograms by this
         factor to unwrap faster, then upsample to full resolution.
+    scratchdir : Filename, optional
+        Path to scratch directory to hold intermediate files.
+        If None, uses `tophu`'s `/tmp/...` default.
     overwrite : bool, optional, default = False
         Overwrite existing unwrapped files.
 
@@ -130,6 +134,7 @@ def run(
                 mask_file=mask_file,
                 downsample_factor=downsample_factor,
                 ntiles=ntiles,
+                scratchdir=scratchdir,
             )
             for ifg_file, out_file, cor_file in zip(in_files, out_files, cor_filenames)
         ]
@@ -161,6 +166,7 @@ def unwrap(
     log_to_file: bool = True,
     downsample_factor: Union[int, tuple[int, int]] = 1,
     ntiles: Union[int, tuple[int, int]] = 1,
+    scratchdir: Optional[Filename] = None,
 ) -> tuple[Path, Path]:
     """Unwrap a single interferogram using isce3's SNAPHU/ICU bindings.
 
@@ -198,6 +204,9 @@ def unwrap(
         Use multi-resolution unwrapping with `tophu` on the interferograms.
         If 1 or (1, 1), doesn't use tophu and unwraps the interferogram as
         one single image.
+    scratchdir : Filename, optional
+        Path to scratch directory to hold intermediate files.
+        If None, uses `tophu`'s `/tmp/...` default.
 
     Returns
     -------
@@ -231,6 +240,7 @@ def unwrap(
             init_method=init_method,
             cost=cost,
             unwrap_method=unwrap_method,
+            scratchdir=scratchdir,
             log_to_file=log_to_file,
         )
 
@@ -408,6 +418,7 @@ def multiscale_unwrap(
     unwrap_method: UnwrapMethod = UnwrapMethod.SNAPHU,
     init_method: str = "mst",
     cost: str = "smooth",
+    scratchdir: Optional[Filename] = None,
     log_to_file: bool = True,
 ) -> tuple[Path, Path]:
     """Unwrap an interferogram using at multiple scales using `tophu`.
@@ -441,7 +452,9 @@ def multiscale_unwrap(
         SNAPHU initialization method, by default "mst"
     cost : str, choices = {"smooth", "defo", "p-norm",}
         SNAPHU cost function, by default "smooth"
-    downsample_factor : int, optional, default = 1
+    scratchdir : Filename, optional
+        Path to scratch directory to hold intermediate files.
+        If None, uses `tophu`'s `/tmp/...` default.
     log_to_file : bool, optional
         Redirect isce3's logging output to file, by default True
 
@@ -529,6 +542,7 @@ def multiscale_unwrap(
         unwrap_func=unwrap_callback,
         downsample_factor=downsample_factor,
         ntiles=ntiles,
+        scratchdir=scratchdir,
     )
 
     return Path(unw_filename), Path(conncomp_filename)

--- a/src/dolphin/workflows/config.py
+++ b/src/dolphin/workflows/config.py
@@ -489,6 +489,8 @@ class Workflow(YamlModel):
         if not self.keep_paths_relative:
             # Save all directories as absolute paths
             self.work_directory = self.work_directory.resolve(strict=False)
+            # Resolve all CSLC paths:
+            self.cslc_file_list = [p.resolve(strict=False) for p in self.cslc_file_list]
 
         work_dir = self.work_directory
         # For each workflow step that has an output folder, move it inside

--- a/src/dolphin/workflows/s1_disp.py
+++ b/src/dolphin/workflows/s1_disp.py
@@ -127,15 +127,19 @@ def run(
     # ###################################
     # 2. Stitch and unwrap interferograms
     # ###################################
-    unwrapped_paths, conncomp_paths, spatial_corr_paths, stitched_tcorr_file = (
-        stitch_and_unwrap.run(
-            ifg_file_list=ifg_file_list,
-            tcorr_file_list=tcorr_file_list,
-            ps_file_list=ps_file_list,
-            cfg=cfg,
-            debug=debug,
-            unwrap_jobs=cfg.unwrap_options.n_parallel_jobs,
-        )
+    (
+        unwrapped_paths,
+        conncomp_paths,
+        spatial_corr_paths,
+        stitched_tcorr_file,
+        stitched_ps_file,
+    ) = stitch_and_unwrap.run(
+        ifg_file_list=ifg_file_list,
+        tcorr_file_list=tcorr_file_list,
+        ps_file_list=ps_file_list,
+        cfg=cfg,
+        debug=debug,
+        unwrap_jobs=cfg.unwrap_options.n_parallel_jobs,
     )
 
     # Print the maximum memory usage for each worker

--- a/src/dolphin/workflows/stitch_and_unwrap.py
+++ b/src/dolphin/workflows/stitch_and_unwrap.py
@@ -44,8 +44,8 @@ def run(
         list of Paths to unwrapped interferograms created.
     conncomp_paths : list[Path]
         list of Paths to connected component files created.
-    spatial_corr_paths : list[Path]
-        list of Paths to spatial correlation files created.
+    interferometric_corr_paths : list[Path]
+        list of Paths to interferometric correlation files created.
     stitched_tcorr_file : Path
         Path to temporal correlation file created.
     stitched_ps_file : Path
@@ -71,8 +71,8 @@ def run(
         out_bounds_epsg=cfg.output_options.bounds_epsg,
     )
 
-    # Estimate the spatial correlation from the stitched interferogram
-    spatial_corr_paths = _estimate_spatial_correlations(
+    # Estimate the interferometric correlation from the stitched interferogram
+    interferometric_corr_paths = _estimate_interferometric_correlations(
         date_to_ifg_path, window_size=cfg.phase_linking.half_window.to_looks()
     )
 
@@ -140,7 +140,7 @@ def run(
 
     unwrapped_paths, conncomp_paths = unwrap.run(
         ifg_filenames=ifg_filenames,
-        cor_filenames=spatial_corr_paths,
+        cor_filenames=interferometric_corr_paths,
         output_path=cfg.unwrap_options._directory,
         nlooks=nlooks,
         mask_file=output_mask,
@@ -154,13 +154,13 @@ def run(
     return (
         unwrapped_paths,
         conncomp_paths,
-        spatial_corr_paths,
+        interferometric_corr_paths,
         stitched_tcorr_file,
         stitched_ps_file,
     )
 
 
-def _estimate_spatial_correlations(
+def _estimate_interferometric_correlations(
     date_to_ifg_path: dict[tuple[date, ...], Path], window_size: tuple[int, int]
 ) -> list[Path]:
     logger = get_log()
@@ -170,12 +170,12 @@ def _estimate_spatial_correlations(
         cor_path = ifg_path.with_suffix(".cor")
         corr_paths.append(cor_path)
         if cor_path.exists():
-            logger.info(f"Skipping existing spatial correlation for {ifg_path}")
+            logger.info(f"Skipping existing interferometric correlation for {ifg_path}")
             continue
         ifg = io.load_gdal(ifg_path)
-        logger.info(f"Estimating spatial correlation for {dates}...")
+        logger.info(f"Estimating interferometric correlation for {dates}...")
         cor = estimate_correlation_from_phase(ifg, window_size=window_size)
-        logger.info(f"Writing spatial correlation to {cor_path}")
+        logger.info(f"Writing interferometric correlation to {cor_path}")
         io.write_arr(
             arr=cor,
             output_name=cor_path,

--- a/src/dolphin/workflows/stitch_and_unwrap.py
+++ b/src/dolphin/workflows/stitch_and_unwrap.py
@@ -133,6 +133,11 @@ def run(
     ifg_filenames = sorted(Path(stitched_ifg_dir).glob("*.int"))  # type: ignore
     if not ifg_filenames:
         raise FileNotFoundError(f"No interferograms found in {stitched_ifg_dir}")
+
+    # Make a scratch directory for unwrapping
+    unwrap_scratchdir = cfg.unwrap_options._directory / "scratch"
+    unwrap_scratchdir.mkdir(exist_ok=True)
+
     unwrapped_paths, conncomp_paths = unwrap.run(
         ifg_filenames=ifg_filenames,
         cor_filenames=spatial_corr_paths,
@@ -143,6 +148,7 @@ def run(
         ntiles=cfg.unwrap_options.ntiles,
         downsample_factor=cfg.unwrap_options.downsample_factor,
         unwrap_method=cfg.unwrap_options.unwrap_method,
+        scratchdir=unwrap_scratchdir,
     )
 
     return (

--- a/src/dolphin/workflows/stitch_and_unwrap.py
+++ b/src/dolphin/workflows/stitch_and_unwrap.py
@@ -19,7 +19,7 @@ def run(
     cfg: Workflow,
     debug: bool = False,
     unwrap_jobs: int = 1,
-) -> tuple[list[Path], list[Path], list[Path], Path]:
+) -> tuple[list[Path], list[Path], list[Path], Path, Path]:
     """Run the displacement workflow on a stack of SLCs.
 
     Parameters
@@ -48,6 +48,8 @@ def run(
         list of Paths to spatial correlation files created.
     stitched_tcorr_file : Path
         Path to temporal correlation file created.
+    stitched_ps_file : Path
+        Path to ps mask file created.
     """
     logger = get_log(debug=debug)
 
@@ -101,7 +103,7 @@ def run(
     # #####################################
     if not cfg.unwrap_options.run_unwrap:
         logger.info("Skipping unwrap step")
-        return [], [], [], stitched_tcorr_file
+        return [], [], [], stitched_tcorr_file, stitched_ps_file
 
     if cfg.mask_file is not None:
         # Check that the input mask is the same size as the ifgs:
@@ -143,7 +145,13 @@ def run(
         unwrap_method=cfg.unwrap_options.unwrap_method,
     )
 
-    return unwrapped_paths, conncomp_paths, spatial_corr_paths, stitched_tcorr_file
+    return (
+        unwrapped_paths,
+        conncomp_paths,
+        spatial_corr_paths,
+        stitched_tcorr_file,
+        stitched_ps_file,
+    )
 
 
 def _estimate_spatial_correlations(

--- a/tests/test_workflows_config.py
+++ b/tests/test_workflows_config.py
@@ -183,7 +183,7 @@ def test_input_relative_paths(tmpdir, slc_file_list_nc):
         opts = config.Workflow(
             cslc_file_list=[newfile],
             input_options={"subdataset": "data"},
-            resolve=False,
+            keep_paths_relative=True,
         )
         assert opts.cslc_file_list == [newfile]
 


### PR DESCRIPTION
We were creating the PS mask, but not passing the filename through to make saving it easy.