### PR TITLE
`asv` benchmark setup

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,80 @@
+# Based off of scikit-image .github/workflows/benchmarks.yml
+# and tqdm .github/workflows/check.yml#L54C1-L54C1
+name: Benchmark
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+  schedule:
+  - cron: '31 1 * * SUN'  # M H d m w (Sundays at 01:31)
+
+jobs:
+  benchmark:
+    if: contains(github.event.label.name, 'benchmark') || github.event_name == 'workflow_dispatch'
+    name: Linux
+    runs-on: ubuntu-latest
+
+    steps:
+      # We need the full repo to avoid this issue
+      # https://github.com/actions/checkout/issues/23
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: "3.11"
+
+      - name: Setup some dependencies
+        shell: bash -l {0}
+        run: |
+          pip install asv
+          asv machine --yes
+      # https://github.com/tqdm/tqdm/blob/4c956c20b83be4312460fc0c4812eeb3fef5e7df/.github/workflows/check.yml#L26
+      - name: Restore previous results
+        uses: actions/cache@v3
+        with:
+          path: .asv
+          key: asv-${{ runner.os }}
+          restore-keys: |
+            asv-
+
+      - name: Run benchmarks
+        shell: bash -l {0}
+        id: benchmark
+        env:
+          OPENBLAS_NUM_THREADS: 1
+          MKL_NUM_THREADS: 1
+          OMP_NUM_THREADS: 1
+        run: |
+          set -x
+
+          echo "Baseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
+          echo "Contender: ${GITHUB_SHA} (${{ github.event.pull_request.head.label }})"
+
+          # Run benchmarks for current commit against base
+          ASV_OPTIONS="--split --show-stderr"
+          asv continuous $ASV_OPTIONS ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA} \
+              | sed "/Traceback \|failed$/ s/^/::error::/" \
+              | tee benchmarks.log
+
+          # Report and export results for subsequent steps
+          if grep "Traceback \|failed" benchmarks.log > /dev/null ; then
+              exit 1
+          fi
+
+      - name: Add instructions to artifact
+        if: always()
+        run: cp benchmarks/README_CI.md benchmarks.log .asv/results/
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: asv-benchmark-results-${{ runner.os }}
+          path: .asv/results
+
+# For now, we're just uploading the artifact
+# If we want to publish to github pages, may want this:
+# https://github.com/tqdm/tqdm/blob/4c956c20b83be4312460fc0c4812eeb3fef5e7df/.github/workflows/check.yml#L54C1-L54C1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     types: [labeled]
   workflow_dispatch:
-  schedule:
-  - cron: '31 1 * * SUN'  # M H d m w (Sundays at 01:31)
 
 jobs:
   benchmark:
@@ -22,15 +20,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
-        name: Install Python
+      - name: Setup environment
+        uses: mamba-org/setup-micromamba@v1
         with:
-          python-version: "3.11"
+          environment-file: requirements.txt
+          environment-name: dolphin
+          condarc: |
+            channels:
+              - conda-forge
+              - nodefaults
+          create-args: >-
+            python=3.11
+            asv>=0.6
 
-      - name: Setup some dependencies
+      - name: Record machine info
         shell: bash -l {0}
         run: |
-          pip install asv
           asv machine --yes
       # https://github.com/tqdm/tqdm/blob/4c956c20b83be4312460fc0c4812eeb3fef5e7df/.github/workflows/check.yml#L26
       - name: Restore previous results

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -6,6 +6,13 @@
     "branches": [
         "main"
     ],
+    // To build the package using pyproject.toml (PEP518), uncomment the following lines
+    "build_command": [
+        "python -m pip install setuptools_scm",
+        "python -m pip install build",
+        "python -m build",
+        "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    ],
     "environment_type": "mamba",
     // timeout in seconds for installing any dependencies in environment
     "install_timeout": 600,

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,38 @@
+{
+    "version": 1,
+    "project": "dolphin",
+    "project_url": "https://dolphin-insar.readthedocs.io/",
+    "repo": ".",
+    "branches": [
+        "main"
+    ],
+    "environment_type": "mamba",
+    // timeout in seconds for installing any dependencies in environment
+    "install_timeout": 600,
+    // the base URL to show a commit for the project.
+    "show_commit_url": "https://github.com/isce-framework/dolphin/commit/",
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    "pythons": [
+        "3.11"
+    ],
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    "conda_channels": [
+        "conda-forge",
+        "defaults"
+    ],
+    // A conda environment file that is used for environment creation.
+    "conda_environment_file": "conda-env.yml",
+    // The directory (relative to the current directory) that benchmarks are stored in.
+    "benchmark_dir": "benchmarks",
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.
+    "env_dir": ".asv/env",
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.
+    "results_dir": ".asv/results",
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.
+    "html_dir": ".asv/html"
+}

--- a/benchmarks/README_CI.md
+++ b/benchmarks/README_CI.md
@@ -1,0 +1,28 @@
+# Benchmark CI
+
+<!-- Taken from scikit-image -->
+<!-- https://github.com/scikit-image/scikit-image/pull/5424 -->
+
+## How it works
+
+The `asv` suite can be run for any PR on GitHub Actions (check workflow `.github/workflows/benchmarks.yml`) by adding a `run-benchmark` label to said PR. This will trigger a job that will run the benchmarking suite for the current PR head (merged commit) against the PR base (usually `main`).
+
+We use `asv continuous` to run the job, which runs a relative performance measurement. This means that there's no state to be saved and that regressions are only caught in terms of performance ratio (absolute numbers are available but they are not useful since we do not use stable hardware over time). `asv continuous` will:
+
+## Running the benchmarks on GitHub Actions
+
+1. On a PR, add the label `run-benchmark`.
+2. The CI job will be started. Checks will appear in the usual dashboard panel above the comment box.
+3. If more commits are added, the label checks will be grouped with the last commit checks _before_ you added the label.
+4. Alternatively, you can always go to the `Actions` tab in the repo and [filter for `workflow:Benchmark`](https://github.com/isce-framework/dolphin/actions?query=workflow%3ABenchmark). Your username will be assigned to the `actor` field, so you can also filter the results with that if you need it.
+
+## The artifacts
+
+The CI job will also generate an artifact. This is the `.asv/results` directory compressed in a zip file. Its contents include:
+
+* `fv-xxxxx-xx/`. A directory for the machine that ran the suite. It contains three files:
+  * `<baseline>.json`, `<contender>.json`: the benchmark results for each commit, with stats.
+  * `machine.json`: details about the hardware.
+* `benchmarks.json`: metadata about the current benchmark suite.
+* `benchmarks.log`: the CI logs for this run.
+* This README.

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,31 +1,109 @@
-# Write the benchmarking functions here.
-# See "Writing benchmarks" in the asv docs for more information.
+import numpy as np
+
+from dolphin import shp
+from dolphin.phase_link import covariance, mle, simulate
+
+# Shared for all tests
+HALF_WINDOW = {"x": 11, "y": 5}
+STRIDES = {"x": 6, "y": 3}
+SHAPE = (512, 512)
 
 
-class TimeSuite:
-    """Example benchmark that times the performance of various kinds."""
+def _make_slc_samples():
+    """Create some sample SLC data."""
+    # Make it as large as the biggest test
+    cov_mat, _ = simulate.simulate_C(
+        num_acq=30,
+        Tau0=72,
+        gamma_inf=0.3,
+        gamma0=0.99,
+        add_signal=True,
+        signal_std=0.01,
+    )
+    return simulate.simulate_neighborhood_stack(
+        cov_mat, neighbor_samples=np.prod(SHAPE)
+    )
+
+
+class CovarianceBenchmark:
+    """Benchmark results for covariance matrix formation."""
+
+    # https://asv.readthedocs.io/en/v0.6.1/writing_benchmarks.html#parameterized-benchmarks
+    # Number of SLCs
+    params = [10, 20, 30]
+
+    def setup_cache(self):
+        # Run the several-second generation of samples once in setup_cache
+        # https://asv.readthedocs.io/en/v0.6.1/writing_benchmarks.html
+        np.save("slc_samples.npy", _make_slc_samples())
+
+    def setup(self, nslc):
+        self.slc_samples = np.load("slc_samples.npy")[:nslc, :]
+        self.slc_stack = self.slc_samples.reshape((nslc, *SHAPE))
+
+    def time_covariance_single(self, nslc):
+        # Test one covariance matrix on part of the samples
+        covariance.coh_mat_single(self.slc_samples[:, :200])
+
+    def time_covariance_stack(self, nslc):
+        covariance.estimate_stack_covariance_cpu(
+            self.slc_stack, half_window=HALF_WINDOW, strides=STRIDES
+        )
+
+    def peakmem_covariance_stack(self, nslc):
+        covariance.estimate_stack_covariance_cpu(
+            self.slc_stack, half_window=HALF_WINDOW, strides=STRIDES
+        )
+
+
+class PhaseLinkingBenchmark:
+    """Benchmark phase linking algorithms."""
+
+    # (nslc, use_evd)
+    params = ([10, 20, 30], [True, False])
+
+    def setup_cache(self):
+        np.save("slc_samples.npy", _make_slc_samples())
+
+    def setup(self, nslc: int, use_evd: bool):
+        self.slc_samples = np.load("slc_samples.npy")[:nslc, :]
+        self.slc_stack = self.slc_samples.reshape((nslc, *SHAPE))
+
+    def time_phase_link(self, nslc: int, use_evd: bool):
+        mle.run_mle(
+            self.slc_stack,
+            half_window=HALF_WINDOW,
+            strides=STRIDES,
+            use_evd=use_evd,
+        )
+
+    def peakmem_phase_link(self, nslc: int, use_evd: bool):
+        mle.run_mle(
+            self.slc_stack,
+            half_window=HALF_WINDOW,
+            strides=STRIDES,
+            use_evd=use_evd,
+        )
+
+
+class ShpBenchmark:
+    """Benchmark suite for SHP estimation functions."""
 
     def setup(self):
-        self.d = {}
-        for x in range(500):
-            self.d[x] = None
+        self.nslc = 30
+        slc_samples = _make_slc_samples()
+        slc_stack = slc_samples.reshape((self.nslc, *SHAPE))
 
-    def time_keys(self):
-        for key in self.d.keys():
-            pass
+        self.amp_mean = np.mean(slc_stack, axis=0)
+        self.amp_variance = np.var(slc_stack, axis=0)
 
-    def time_values(self):
-        for value in self.d.values():
-            pass
-
-    def time_range(self):
-        d = self.d
-        for key in range(500):
-            d[key]
-
-
-class MemSuite:
-    """Classify memory."""
-
-    def mem_list(self):
-        return [0] * 256
+    def time_estimate_neighbors(self):
+        shp.estimate_neighbors(
+            halfwin_rowcol=(HALF_WINDOW["y"], HALF_WINDOW["x"]),
+            alpha=0.001,
+            strides=STRIDES,
+            mean=self.amp_mean,
+            var=self.amp_variance,
+            nslc=30,
+            method=shp.ShpMethod.GLRT,
+        )

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -96,8 +96,8 @@ class ShpBenchmark:
         slc_samples = _make_slc_samples()
         slc_stack = slc_samples.reshape((self.nslc, *SHAPE))
 
-        self.amp_mean = np.mean(slc_stack, axis=0)
-        self.amp_variance = np.var(slc_stack, axis=0)
+        self.amp_mean = np.mean(np.abs(slc_stack), axis=0)
+        self.amp_variance = np.var(np.abs(slc_stack), axis=0)
 
     def time_estimate_neighbors(self):
         shp.estimate_neighbors(

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,0 +1,31 @@
+# Write the benchmarking functions here.
+# See "Writing benchmarks" in the asv docs for more information.
+
+
+class TimeSuite:
+    """Example benchmark that times the performance of various kinds."""
+
+    def setup(self):
+        self.d = {}
+        for x in range(500):
+            self.d[x] = None
+
+    def time_keys(self):
+        for key in self.d.keys():
+            pass
+
+    def time_values(self):
+        for value in self.d.values():
+            pass
+
+    def time_range(self):
+        d = self.d
+        for key in range(500):
+            d[key]
+
+
+class MemSuite:
+    """Classify memory."""
+
+    def mem_list(self):
+        return [0] * 256

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -29,8 +29,9 @@ class CovarianceBenchmark:
     """Benchmark results for covariance matrix formation."""
 
     # https://asv.readthedocs.io/en/v0.6.1/writing_benchmarks.html#parameterized-benchmarks
-    # Number of SLCs
+    # Parameterize by the number of SLCs
     params = [10, 20, 30]
+    param_names = ["nslc"]
 
     def setup_cache(self):
         # Run the several-second generation of samples once in setup_cache
@@ -61,6 +62,7 @@ class PhaseLinkingBenchmark:
 
     # (nslc, use_evd)
     params = ([10, 20, 30], [True, False])
+    param_names = ["nslc", "use_evd"]
 
     def setup_cache(self):
         np.save("slc_samples.npy", _make_slc_samples())

--- a/scripts/test_run_bench.sh
+++ b/scripts/test_run_bench.sh
@@ -3,10 +3,12 @@ set -e
 
 # Save the commits hashes for all tagged releases
 # Only look for ones past version 0.4.1 (which added `evd` option)
-git show-ref --tags | awk '$2>="refs/tags/v0.4.1" { print $1; } ' >tag_hashlist.txt
+git show-ref --tags | awk '$2 >= "refs/tags/v0.4.2" { print $1; } ' >tag_hashlist.txt
 
 num_threads=${NUM_THREADS:-16}
-NUMBA_NUM_THREADS=$num_threads
-OMP_NUM_THREADS=$num_threads
-OPENBLAS_NUM_THREADS=$num_threads
-asv run HASHFILE:tag_hashlist.txt --cpu-affinity 0-15 --show-stderr
+export NUMBA_NUM_THREADS=$num_threads
+export OMP_NUM_THREADS=$num_threads
+export OPENBLAS_NUM_THREADS=$num_threads
+asv run HASHFILE:tag_hashlist.txt --skip-existing-commits \
+    --cpu-affinity 0-15 \
+    --show-stderr

--- a/scripts/test_run_bench.sh
+++ b/scripts/test_run_bench.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Save the commits hashes for all tagged releases
+# Only look for ones past version 0.4.1 (which added `evd` option)
+git show-ref --tags | awk '$2>="refs/tags/v0.4.1" { print $1; } ' >tag_hashlist.txt
+
+num_threads=${NUM_THREADS:-16}
+NUMBA_NUM_THREADS=$num_threads
+OMP_NUM_THREADS=$num_threads
+OPENBLAS_NUM_THREADS=$num_threads
+asv run HASHFILE:tag_hashlist.txt --cpu-affinity 0-15 --show-stderr

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+asv
 black
 flake8
 pooch


### PR DESCRIPTION
(Dumping some of my initial notes about why I ended up picking this)

Airspeed Velocity ([`asv`](https://asv.readthedocs.io/en/v0.6.1/)) seems to be the best existing way to run a few benchmarks and get progress over time. It's used by `numpy`, `pandas`, `scikit-image`, `xarray`, and a few others.

### Basics: making these new configuration files, and running test benchmarks

1. I installed `asv` (which is added to the `test` requirements), ran `asf quickstart` to make a template `asv.conf.json`, then filled it out
2. To run locally, you can run `asv machine` or `asv machine --yes` to have it save info about the computer you are on
3. Runing benchmarks with `asv run` will install the environment(s) that are specified, and these can be reused for future runs.
4. You compile the results with `asv publish`, and view locally with `asv preview`

### Naming the benchmark tests

The benchmarks almost look like normal `pytest` or `UnitTest` files, except all the names have `time_` or `mem_` as the function names... And that's because `asv` will use that to figure out what it's tracking
- `time_<blah>` will run a function (and call the result whatever you've named this function). and measure the runtime
- `peakmem_<blah>` records the peak memory usage

### Using it in CI

- You can run against a specific git commit, or a tag, like 
```
asv run v0.5.0^!
```
This PR is attempting to have a nice way to trigger this on Github actions only if you want it run on specific PRs (which I do), rather than every single change/push.
This section of the new Github Action:
```yaml
on:
  pull_request:
    types: [labeled]

jobs:
  benchmark:
    if: ${{ github.event.label.name == 'run-benchmark' && github.event_name == 'pull_request' }}
```
means that when you label a PR with "run-benchmark" it should kick off the `asv` workflow. If you add more commits, you'll need to remove and re-add if you want it run again. You can also go to the "Actions" tab to run it.

### Running on our big server

I started the `test_run_bench.sh` script for running on aurora, where I manually set the number of threads and use `asv`s `--cpu-affinity 0-15 ` option to really limit the number of cores.

(The problem with only running this on the CI is that it'll be single CPU... we're also interested in how the main functions perform with access to multiple CPUs, since that's the more realistic setting. Open to discussing this part more.)

### Examples repos' example usages
- [TQDM has a longer GHA workflow using it on a scheduled cron](https://github.com/tqdm/tqdm/blob/4c956c20b83be4312460fc0c4812eeb3fef5e7df/.github/workflows/check.yml#L26)
- [scikit-image](https://github.com/scikit-image/scikit-image/blob/12be1553f2d439fe997052293b3fe8fcdf69f6f6/.github/workflows/benchmarks.yml) has a regular version, but also [a cron version](https://github.com/jaimergp/scikit-image/blob/e561996df7daa3d7164326c5c29cc6898c32518f/.github/workflows/benchmarks-cron.yml#L3-L7), and their docs have a lot of nice [info about running/adding to their benchmarks](https://scikit-image.org/docs/stable/development/contribute.html#benchmarks) 
- [Scipy has docs about it here](https://docs.scipy.org/doc/scipy/dev/contributor/benchmarking.html) and their [graphs are up here](https://pv.github.io/scipy-bench/)
- [scikit-learn has a separate repo setup](https://github.com/scikit-learn/scikit-learn-benchmarks)
- [Sarsen has a simple setup](https://github.com/bopen/sarsen-benchmarks/blob/main/.github/workflows/benchmark-and-deploy.yml), but they've put semi-real data into git LFS... which is probably why it's in a separate repo
- [napari has a complicated GHA setup](https://github.com/Czaki/napari/blob/1b1baa8291ff03fb7732b9ca27b33ef471da0b71/.github/workflows/benchmarks.yml)