### PR TITLE
Add `@atomic_output` decorator for outputs that get written to in blocks

### DIFF
--- a/src/dolphin/_decorators.py
+++ b/src/dolphin/_decorators.py
@@ -1,0 +1,111 @@
+import functools
+import inspect
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from dolphin._log import get_log
+from dolphin._types import Filename
+
+logger = get_log(__name__)
+
+__all__ = [
+    "atomic_output",
+]
+
+
+def atomic_output(
+    function: Optional[Callable] = None,
+    output_arg: str = "output_file",
+    is_dir: bool = False,
+    scratch_dir: Optional[Filename] = None,
+) -> Callable:
+    """Use a temporary file/directory for the `output_arg` until the function finishes.
+
+    Decorator is used on a function which writes to an output file/directory in blocks.
+    If the function were interrupted, the file/directory would be partiall complete.
+
+    This decorator replaces the final output name with a temp file/dir, and then
+    renames the temp file/dir to the final name after the function finishes.
+
+    Note that when `is_dir=True`, `output_arg` can be a directory (if multiple files
+    are being written to). In this case, the entire directory is temporary, and
+    renamed after the function finishes.
+
+    Parameters
+    ----------
+    function : Optional[Callable]
+        Used if the decorator is called without any arguments (i.e. as
+        `@atomic_output` instead of `@atomic_output(output_arg=...)`)
+    output_arg : str, optional
+        The name of the argument to replace, by default 'output_file'
+    is_dir : bool, default = False
+        If True, the output argument is a directory, not a file
+    scratch_dir : Optional[Filename]
+        The directory to use for the temporary file, by default None
+        If None, uses the same directory as the final requested output.
+
+    Returns
+    -------
+    Callable
+        The decorated function
+    """
+
+    def actual_decorator(func: Callable) -> Callable:
+        # Want to be able to use this decorator with or without arguments:
+        # https://stackoverflow.com/a/19017908/4174466
+        # Code adapted from the `@login_required` decorator in Django:
+        # https://github.com/django/django/blob/d254a54e7f65e83d8971bd817031bc6af32a7a46/django/contrib/auth/decorators.py#L43  # noqa
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs) -> Any:
+            # Extract the output file path
+            if output_arg in kwargs:
+                final_out_name = kwargs[output_arg]
+            else:
+                sig = inspect.signature(func)
+                if output_arg in sig.parameters:
+                    final_out_name = sig.parameters[output_arg].default
+                else:
+                    raise ValueError(
+                        f"Argument {output_arg} not found in function {func.__name__}"
+                    )
+
+            final_path = Path(final_out_name)
+            if scratch_dir is None:
+                tmp_dir = final_path.parent
+            else:
+                tmp_dir = None
+
+            prefix = final_path.name
+            if is_dir:
+                # Create a temporary directory
+                temp_path = tempfile.mkdtemp(dir=tmp_dir, prefix=prefix)
+            else:
+                # Create a temporary file
+                _, temp_path = tempfile.mkstemp(dir=tmp_dir, prefix=prefix)
+            logger.debug("Writing to temp file %s instead of %s", temp_path, final_path)
+
+            try:
+                # Replace the output file path with the temp file
+                kwargs[output_arg] = temp_path
+                # Execute the original function
+                result = func(*args, **kwargs)
+                # Move the temp file to the final location
+                shutil.move(temp_path, final_path)
+
+                return result
+            finally:
+                logger.debug("Cleaning up temp file %s", temp_path)
+                if is_dir:
+                    shutil.rmtree(temp_path, ignore_errors=True)
+                else:
+                    Path(temp_path).unlink(missing_ok=True)
+
+        return wrapper
+
+    if function is not None:
+        # Decorator used without arguments
+        return actual_decorator(function)
+    # Decorator used with arguments
+    return actual_decorator

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,96 @@
+import threading
+import time
+from pathlib import Path
+
+from dolphin._decorators import atomic_output
+
+
+def _long_write(filename, pause: float = 0.2):
+    """Simulate a long writing process"""
+    f = open(filename, "w")
+    f.write("aaa\n")
+    time.sleep(pause)
+    f.write("bbb\n")
+    f.close()
+
+
+@atomic_output
+def default_write(output_file="out.txt"):
+    _long_write(output_file)
+
+
+@atomic_output(output_arg="outname")
+def default_write_newname(outname="out3.txt"):
+    _long_write(outname)
+
+
+@atomic_output(output_arg="output_dir")
+def default_write_dir(output_dir="some_dir"):
+    p = Path(output_dir)
+    p.mkdir(exist_ok=True)
+    outname = p / "testfile.txt"
+    _long_write(outname)
+
+
+def test_atomic_output(tmpdir):
+    with tmpdir.as_cwd():
+        default_write()
+        default_write(output_file="out2.txt")
+        default_write_newname()
+        default_write_newname(outname="out4.txt")
+        for fn in ["out.txt", "out2.txt", "out3.txt", "out4.txt"]:
+            assert Path(fn).exists()
+
+
+def test_atomic_output_name_swap(tmpdir):
+    # Kick off the writing function in the background
+    # so we see if a different file was created
+    with tmpdir.as_cwd():
+        # Check it works providing the "args"
+        t = threading.Thread(target=default_write)
+        t.start()
+        # It should NOT exist, yet
+        assert not Path("out.txt").exists()
+        time.sleep(0.5)
+        assert Path("out.txt").exists()
+        Path("out.txt").unlink()
+
+
+def test_atomic_output_name_swap_with_args(tmpdir):
+    with tmpdir.as_cwd():
+        outname2 = "out2.txt"
+        t = threading.Thread(target=default_write, args=(outname2,))
+        t.start()
+        # It should NOT exist, yet
+        assert not Path(outname2).exists()
+        time.sleep(0.5)
+        t.join()
+        assert Path(outname2).exists()
+        Path(outname2).unlink()
+
+
+def test_atomic_output_name_swap_with_kwargs(tmpdir):
+    with tmpdir.as_cwd():
+        outname2 = "out3.txt"
+        t = threading.Thread(target=default_write_newname, kwargs={"outname": outname2})
+        t.start()
+        # It should NOT exist, yet
+        assert not Path(outname2).exists()
+        time.sleep(0.5)
+        t.join()
+        assert Path(outname2).exists()
+        Path(outname2).unlink()
+
+
+def test_atomic_output_dir_name_swap(tmpdir):
+    # Kick off the writing function in the background
+    # so we see if a different file was created
+    with tmpdir.as_cwd():
+        # Check it works providing the "args"
+        t = threading.Thread(target=default_write)
+        t.start()
+        # It should NOT exist, yet
+        assert not Path("out.txt").exists()
+        time.sleep(0.5)
+        assert Path("out.txt").exists()
+        Path("out.txt").unlink()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -14,62 +14,63 @@ def _long_write(filename, pause: float = 0.2):
     f.close()
 
 
-@atomic_output
-def default_write(output_file="out.txt"):
-    _long_write(output_file)
-
-
 @atomic_output(output_arg="outname")
-def default_write_newname(outname="out3.txt"):
+def default_write_newname(outname="out.txt"):
     _long_write(outname)
 
 
-@atomic_output(output_arg="output_dir")
-def default_write_dir(output_dir="some_dir"):
+@atomic_output(output_arg="outname", use_tmp=True)
+def default_write_newname_tmp(outname="out.txt"):
+    _long_write(outname)
+
+
+@atomic_output(output_arg="output_dir", is_dir=True)
+def default_write_dir(output_dir="some_dir", filename="testfile.txt"):
     p = Path(output_dir)
-    p.mkdir(exist_ok=True)
-    outname = p / "testfile.txt"
+    p.mkdir(exist_ok=True, parents=True)
+    outname = p / filename
+    _long_write(outname)
+
+
+@atomic_output(output_arg="output_dir", is_dir=True, use_tmp=True)
+def default_write_dir_tmp(output_dir="some_dir", filename="testfile.txt"):
+    p = Path(output_dir)
+    p.mkdir(exist_ok=True, parents=True)
+    outname = p / filename
     _long_write(outname)
 
 
 def test_atomic_output(tmpdir):
     with tmpdir.as_cwd():
-        default_write()
-        default_write(output_file="out2.txt")
-        default_write_newname()
-        default_write_newname(outname="out4.txt")
-        for fn in ["out.txt", "out2.txt", "out3.txt", "out4.txt"]:
+        default_write_newname(outname="out1.txt")
+        default_write_newname(outname="out2.txt")
+        for fn in ["out1.txt", "out2.txt"]:
             assert Path(fn).exists()
 
 
-def test_atomic_output_name_swap(tmpdir):
-    # Kick off the writing function in the background
-    # so we see if a different file was created
+def test_atomic_output_tmp(tmpdir):
     with tmpdir.as_cwd():
-        # Check it works providing the "args"
-        t = threading.Thread(target=default_write)
-        t.start()
-        # It should NOT exist, yet
-        assert not Path("out.txt").exists()
-        time.sleep(0.5)
-        assert Path("out.txt").exists()
-        Path("out.txt").unlink()
+        default_write_newname_tmp(outname="out1.txt")
+        assert Path("out1.txt").exists()
 
 
-def test_atomic_output_name_swap_with_args(tmpdir):
-    with tmpdir.as_cwd():
-        outname2 = "out2.txt"
-        t = threading.Thread(target=default_write, args=(outname2,))
-        t.start()
-        # It should NOT exist, yet
-        assert not Path(outname2).exists()
-        time.sleep(0.5)
-        t.join()
-        assert Path(outname2).exists()
-        Path(outname2).unlink()
+def test_atomic_output_dir(tmp_path):
+    out_dir = tmp_path / "out"
+    filename = "testfile.txt"
+    out_dir.mkdir()
+    default_write_dir(output_dir=out_dir, filename=filename)
+    assert Path(out_dir / filename).exists()
 
 
-def test_atomic_output_name_swap_with_kwargs(tmpdir):
+def test_atomic_output_dir_tmp(tmp_path):
+    out_dir = tmp_path / "out"
+    filename = "testfile.txt"
+    out_dir.mkdir()
+    default_write_dir(output_dir=out_dir, filename=filename)
+    assert Path(out_dir / filename).exists()
+
+
+def test_atomic_output_name_swap_file(tmpdir):
     with tmpdir.as_cwd():
         outname2 = "out3.txt"
         t = threading.Thread(target=default_write_newname, kwargs={"outname": outname2})
@@ -79,18 +80,18 @@ def test_atomic_output_name_swap_with_kwargs(tmpdir):
         time.sleep(0.5)
         t.join()
         assert Path(outname2).exists()
-        Path(outname2).unlink()
 
 
-def test_atomic_output_dir_name_swap(tmpdir):
+def test_atomic_output_dir_swap(tmp_path):
     # Kick off the writing function in the background
     # so we see if a different file was created
-    with tmpdir.as_cwd():
-        # Check it works providing the "args"
-        t = threading.Thread(target=default_write)
-        t.start()
-        # It should NOT exist, yet
-        assert not Path("out.txt").exists()
-        time.sleep(0.5)
-        assert Path("out.txt").exists()
-        Path("out.txt").unlink()
+    # Check it works providing the "args"
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    t = threading.Thread(target=default_write_dir, kwargs={"output_dir": out_dir})
+    t.start()
+    # It should NOT exist, yet
+    assert not Path(out_dir / "testfile.txt").exists()
+    time.sleep(0.5)
+    t.join()
+    assert Path(out_dir / "testfile.txt").exists()


### PR DESCRIPTION
Used for long running parts where, if a process is interrupted, currently there would be a half-empty file with the expected output name. This replaces the final output name with a tempfile, then swaps it only after the process is complete.

closes #110