### PR TITLE
Add unit test for separate workflows with CCSLCs

### DIFF
--- a/tests/test_workflows_displacement.py
+++ b/tests/test_workflows_displacement.py
@@ -134,3 +134,14 @@ def test_separate_workflow_runs(slc_file_list, tmp_path):
     all_ifgs_names = [f.name for f in all_ifgs]
     batched_names = [f.name for f in ifgs1 + ifgs2 + ifgs3]
     assert all_ifgs_names == batched_names
+
+    # Last, try one where we dont have the first CCSLC
+    # The metadata should still tell it what the reference date is,
+    # So the outputs should be the same
+    p3_b = tmp_path / Path("third")
+    files3_b = new_comp_slcs2 + file_batches[2]
+    run_displacement_stack(p3_b, files3_b)
+    ifgs3_b = sorted((p3_b / "interferograms/stitched").glob("*.int"))
+    assert len(ifgs3_b) == 10
+    # Names should be the same as the previous run
+    assert [f.name for f in ifgs3_b] == [f.name for f in ifgs3]

--- a/tests/test_workflows_displacement.py
+++ b/tests/test_workflows_displacement.py
@@ -56,16 +56,18 @@ def test_displacement_run_single_official_opera_naming(
         displacement.run(cfg)
 
 
-def run_displacement_stack(path, file_list: list[Path]):
+def run_displacement_stack(
+    path, file_list: list[Path], run_unwrap: bool = False, ministack_size: int = 500
+):
     cfg = config.DisplacementWorkflow(
         cslc_file_list=file_list,
         input_options=dict(subdataset="/data/VV"),
         work_directory=path,
         phase_linking=dict(
-            ministack_size=500,
+            ministack_size=ministack_size,
         ),
         worker_settings=dict(gpu_enabled=(os.environ.get("NUMBA_DISABLE_JIT") != "1")),
-        unwrap_options=dict(run_unwrap=False),
+        unwrap_options=dict(run_unwrap=run_unwrap),
         log_file=Path(".") / "dolphin.log",
     )
     displacement.run(cfg)
@@ -92,3 +94,43 @@ def test_stack_with_compressed(opera_slc_files, tmpdir):
         ifgs2 = sorted((p2 / "interferograms/stitched").glob("*.int"))
         assert len(ifgs1) > 0
         assert [f.name for f in ifgs1] == [f.name for f in ifgs2]
+
+
+def test_separate_workflow_runs(slc_file_list, tmp_path):
+    """Check that manually running the workflow results in the same
+    interferograms as one sequential run.
+    """
+    p_all = tmp_path / "all"
+    run_displacement_stack(p_all, slc_file_list, ministack_size=10)
+    all_ifgs = sorted((p_all / "interferograms/stitched").glob("*.int"))
+    assert len(all_ifgs) == 29
+
+    p1 = tmp_path / Path("first")
+    ms = 10
+    # Split into batches of 10
+    file_batches = [slc_file_list[i : i + ms] for i in range(0, len(slc_file_list), ms)]
+    assert len(file_batches) == 3
+    assert all(len(b) == 10 for b in file_batches)
+    run_displacement_stack(p1, file_batches[0])
+    new_comp_slcs1 = sorted((p1 / "linked_phase").glob("compressed_*"))
+    assert len(new_comp_slcs1) == 1
+    ifgs1 = sorted((p1 / "interferograms/stitched").glob("*.int"))
+    assert len(ifgs1) == 9
+
+    p2 = tmp_path / Path("second")
+    files2 = new_comp_slcs1 + file_batches[1]
+    run_displacement_stack(p2, files2)
+    new_comp_slcs2 = sorted((p2 / "linked_phase").glob("compressed_*"))
+    assert len(new_comp_slcs2) == 1
+    ifgs2 = sorted((p2 / "interferograms/stitched").glob("*.int"))
+    assert len(ifgs2) == 10
+
+    p3 = tmp_path / Path("third")
+    files3 = new_comp_slcs1 + new_comp_slcs2 + file_batches[2]
+    run_displacement_stack(p3, files3)
+    ifgs3 = sorted((p3 / "interferograms/stitched").glob("*.int"))
+    assert len(ifgs3) == 10
+
+    all_ifgs_names = [f.name for f in all_ifgs]
+    batched_names = [f.name for f in ifgs1 + ifgs2 + ifgs3]
+    assert all_ifgs_names == batched_names


### PR DESCRIPTION
Making a more thorough test for when we split up ministacks into completely separate workflow runs. Just verifying the fixes from #164 