### PR TITLE
Switch naming from `tcorr`, add `unwrap_callback` argument option

### DIFF
--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -89,7 +89,7 @@ def run(
         wrapped_phase_cfgs = [(b, cfg)]
 
     ifg_file_list: list[Path] = []
-    tcorr_file_list: list[Path] = []
+    temp_coh_file_list: list[Path] = []
     ps_file_list: list[Path] = []
     # The comp_slc tracking object is a dict, since we'll need to organize
     # multiple comp slcs by burst (they'll have the same filename)
@@ -115,10 +115,10 @@ def run(
         for fut in fut_to_burst:
             burst = fut_to_burst[fut]
 
-            cur_ifg_list, comp_slc, tcorr, ps_file = fut.result()
+            cur_ifg_list, comp_slc, temp_coh, ps_file = fut.result()
             ifg_file_list.extend(cur_ifg_list)
             comp_slc_dict[burst] = comp_slc
-            tcorr_file_list.append(tcorr)
+            temp_coh_file_list.append(temp_coh)
             ps_file_list.append(ps_file)
 
     # ###################################
@@ -128,11 +128,11 @@ def run(
         unwrapped_paths,
         conncomp_paths,
         spatial_corr_paths,
-        stitched_tcorr_file,
+        stitched_temp_coh_file,
         stitched_ps_file,
     ) = stitch_and_unwrap.run(
         ifg_file_list=ifg_file_list,
-        tcorr_file_list=tcorr_file_list,
+        temp_coh_file_list=temp_coh_file_list,
         ps_file_list=ps_file_list,
         cfg=cfg,
         debug=debug,

--- a/src/dolphin/workflows/sequential.py
+++ b/src/dolphin/workflows/sequential.py
@@ -128,7 +128,8 @@ def run_wrapped_phase_sequential(
     ##############################################
 
     # Average the temporal coherence files in each ministack
-    output_temp_coh_file = output_folder / "temporal_coherence_average.tif"
+    full_span = ministack_planner.real_slc_date_range_str
+    output_temp_coh_file = output_folder / f"temporal_coherence_average_{full_span}.tif"
     # we can pass the list of files to gdal_calc, which interprets it
     # as a multi-band file
     if len(temp_coh_files) > 1:

--- a/src/dolphin/workflows/sequential.py
+++ b/src/dolphin/workflows/sequential.py
@@ -67,8 +67,8 @@ def run_wrapped_phase_sequential(
 
     # list where each item is [output_slc_files] from a ministack
     output_slc_files: list[list] = []
-    # Each item is the tcorr file from a ministack
-    tcorr_files: list[Path] = []
+    # Each item is the temp_coh file from a ministack
+    temp_coh_files: list[Path] = []
 
     # function to check if a ministack has already been processed
     def already_processed(d: Path, search_ext: str = ".tif") -> bool:
@@ -119,34 +119,33 @@ def run_wrapped_phase_sequential(
                 gpu_enabled=gpu_enabled,
             )
 
-        cur_output_files, cur_comp_slc_file, tcorr_file = _get_outputs_from_folder(
+        cur_output_files, cur_comp_slc_file, temp_coh_file = _get_outputs_from_folder(
             cur_output_folder
         )
         output_slc_files.append(cur_output_files)
-        tcorr_files.append(tcorr_file)
+        temp_coh_files.append(temp_coh_file)
 
     ##############################################
 
     # Average the temporal coherence files in each ministack
-    # TODO: do we want to include the date span in this filename?
-    output_tcorr_file = output_folder / "tcorr_average.tif"
+    output_temp_coh_file = output_folder / "temporal_coherence_average.tif"
     # we can pass the list of files to gdal_calc, which interprets it
     # as a multi-band file
-    if len(tcorr_files) > 1:
-        logger.info(f"Averaging temporal coherence files into: {output_tcorr_file}")
+    if len(temp_coh_files) > 1:
+        logger.info(f"Averaging temporal coherence files into: {output_temp_coh_file}")
         gdal_calc.Calc(
             NoDataValue=0,
             format="GTiff",
-            outfile=fspath(output_tcorr_file),
+            outfile=fspath(output_temp_coh_file),
             type="Float32",
             quiet=True,
             overwrite=True,
             creation_options=io.DEFAULT_TIFF_OPTIONS,
-            A=tcorr_files,
+            A=temp_coh_files,
             calc="numpy.nanmean(A, axis=0)",
         )
     else:
-        tcorr_files[0].rename(output_tcorr_file)
+        temp_coh_files[0].rename(output_temp_coh_file)
 
     # Combine the separate SLC output lists into a single list
     all_slc_files = list(chain.from_iterable(output_slc_files))
@@ -162,11 +161,11 @@ def run_wrapped_phase_sequential(
         p.rename(output_folder / p.name)
         comp_outputs.append(output_folder / p.name)
 
-    return pl_outputs, comp_outputs, output_tcorr_file
+    return pl_outputs, comp_outputs, output_temp_coh_file
 
 
 def _get_outputs_from_folder(output_folder: Path):
     cur_output_files = sorted(output_folder.glob("2*.slc.tif"))
     cur_comp_slc_file = next(output_folder.glob("compressed_*"))
-    tcorr_file = next(output_folder.glob("tcorr_*"))
-    return cur_output_files, cur_comp_slc_file, tcorr_file
+    temp_coh_file = next(output_folder.glob("temporal_coherence_*"))
+    return cur_output_files, cur_comp_slc_file, temp_coh_file

--- a/src/dolphin/workflows/single.py
+++ b/src/dolphin/workflows/single.py
@@ -119,7 +119,9 @@ def run_wrapped_phase_single(
     start_end = ministack.real_slc_date_range_str
     output_files: list[OutputFile] = [
         OutputFile(output_folder / comp_slc_info.filename, np.complex64),
-        OutputFile(output_folder / f"tcorr_{start_end}.tif", np.float32, strides),
+        OutputFile(
+            output_folder / f"temporal_coherence_{start_end}.tif", np.float32, strides
+        ),
         OutputFile(output_folder / f"avg_coh_{start_end}.tif", np.uint16, strides),
         OutputFile(output_folder / f"shp_counts_{start_end}.tif", np.uint16, strides),
     ]
@@ -181,7 +183,7 @@ def run_wrapped_phase_single(
         # Run the phase linking process on the current ministack
         reference_idx = max(0, first_real_slc_idx - 1)
         try:
-            cur_mle_stack, tcorr, avg_coh = run_mle(
+            cur_mle_stack, temp_coh, avg_coh = run_mle(
                 cur_data,
                 half_window=half_window,
                 strides=strides,
@@ -210,7 +212,7 @@ def run_wrapped_phase_single(
 
         # Fill in the nan values with 0
         np.nan_to_num(cur_mle_stack, copy=False)
-        np.nan_to_num(tcorr, copy=False)
+        np.nan_to_num(temp_coh, copy=False)
 
         # Save each of the MLE estimates (ignoring those corresponding to
         # compressed SLCs indexes)
@@ -249,7 +251,7 @@ def run_wrapped_phase_single(
         )
 
         # All other outputs are strided (smaller in size)
-        out_datas = [tcorr, avg_coh, shp_counts]
+        out_datas = [temp_coh, avg_coh, shp_counts]
         for data, output_file in zip(out_datas, output_files[1:]):
             if data is None:  # May choose to skip some outputs, e.g. "avg_coh"
                 continue

--- a/tests/test_workflows_single.py
+++ b/tests/test_workflows_single.py
@@ -46,4 +46,4 @@ def test_sequential_gtiff(tmp_path, slc_file_list, gpu_enabled):
     # Check that all the expected outputs are there
     assert len(list(output_folder.glob("2*.slc.tif"))) == 3
     assert len(list(output_folder.glob("compressed_*tif"))) == 1
-    assert len(list(output_folder.glob("tcorr_*tif"))) == 1
+    assert len(list(output_folder.glob("temporal_coherence*tif"))) == 1


### PR DESCRIPTION
- `tcorr` is a bad name
- add the date range to the output filename from `sequential` so we can merge directories later without clobbering
- Add `unwrap_callback` to `unwrap.multiscale_uwnrap` so we can pass any function to `tophu`