### PR TITLE
Drop pydocstyle in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v0.1.9
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--fix, --exit-non-zero-on-fix, --show-fixes]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
@@ -35,11 +35,3 @@ repos:
         - types-pkg_resources
         - types-requests
         - "pydantic>=2.4"
-
-  - repo: https://github.com/PyCQA/pydocstyle
-    rev: "6.3.0"
-    hooks:
-      - id: pydocstyle
-        # https://github.com/PyCQA/pydocstyle/pull/608#issuecomment-1381168417
-        additional_dependencies: ['.[toml]']
-        exclude: tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Switched output filename from `tcorr` to `temporal_coherence` for the temporal coherence of phase linking.
   - Also added the date span to the `temporal_coherence` output name
 - The default extension for conncomps is now `.tif`. Use geotiffs instead of ENVI format for connected components.
+- Using ruff instead of pydocstyle due to archived repo
 
 
 # [v0.7.0](https://github.com/isce-framework/dolphin/compare/v0.6.1...v0.7.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Added**
 - Ability to unwrap interferorgams with the [`snaphu-py`](https://github.com/isce-framework/snaphu-py) (not a required dependency)
 - Added ability to make annual ifgs in `Network`
+- Start of tropospheric corection support in `dolphin.atmosphere` using PyAPS and Raider packages
+- Expose the unwrap skipping with `dolphin config --no-unwrap`
 
 **Changed**
 - The output directory for interferograms is now just "interferograms/" instead of "interferograms/stiched"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,14 @@ version_scheme = "no-guess-dev" # Will not guess the next version
 
 [tool.ruff]
 src = ["src"]
+ignore = [
+  "D100", # Missing docstring in public module
+  "D104", # Missing docstring in public package
+  "D105", # Missing docstring in magic method
+  "D203", # 1 blank line required before class docstring
+  "D212", # Multi-line docstring summary should start at the first line
+  "PLR",  # Pylint Refactor
+]
 
 [tool.ruff.lint]
 # Enable the isort rules.
@@ -65,9 +73,10 @@ python_version = "3.10"
 ignore_missing_imports = true
 plugins = ["pydantic.mypy"]
 
+[tool.ruff.per-file-ignores]
+"**/__init__.py" = ["F401"]
+"test/**" = ["D"]
 
-[tool.pydocstyle]
-ignore = "D100,D102,D104,D105,D106,D107,D203,D204,D213,D413"
 
 [tool.pytest.ini_options]
 doctest_optionflags = "NORMALIZE_WHITESPACE NUMBER"


### PR DESCRIPTION
Take more `pyproject.toml` config from Geoff