### PR TITLE
Add `RasterReader` and `RasterStackReader` implementations

### DIFF
--- a/.github/workflows/test-build-push.yml
+++ b/.github/workflows/test-build-push.yml
@@ -33,6 +33,7 @@ jobs:
               pydantic=2.1
               pymp-pypi=0.4.5
               pyproj=3.3
+              rasterio=1.3
               rich=12.0
               ruamel_yaml=0.15
               scipy=1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
-# [Unreleased](https://github.com/isce-framework/dolphin/compare/v0.8.0...main)
+# [Unreleased](https://github.com/isce-framework/dolphin/compare/v0.9.0...main)
+
+# [v0.9.0](https://github.com/isce-framework/dolphin/compare/v0.8.0...v0.9.0)
+
+**Added**
+- `DatasetReader` and `StackReader` protocols for reading in data from different sources
+  - `DatasetReader` is for reading in a single dataset, like one raster image.
+  - `StackReader` is for reading in a stack of datasets, like a stack of SLCs.
+  - Implementations of these have been done for flat binary files (`BinaryReader`), HDF5 files (`HDF5Reader`), and GDAL rasters (`RasterReader`).
+
+**Changed**
+- The `VRTStack` no longer has an `.iter_blocks` method
+  - This has been replaced with creating an `EagerLoader` directly and passing it to the `reader` argument
 
 # [v0.8.0](https://github.com/isce-framework/dolphin/compare/v0.7.0...v0.8.0)
 

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -15,6 +15,7 @@ dependencies:
   - pydantic>=2.1
   - pymp-pypi>=0.4.5
   - pyproj>=3.3
+  - rasterio>=1.3
   - rich>=12.0
   - ruamel.yaml>=0.15
   - scipy>=1.5 # "scipy 0.16+ is required for linear algebra", numba. 1.5 is the oldest version that supports Python 3.7

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ theme:
 plugins:
 - search
 # plugin suggestions from here: https://mkdocstrings.github.io/recipes/
+- autorefs
 - gen-files:
     scripts:
     - docs/gen_ref_pages.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,8 @@ plugins = ["pydantic.mypy"]
 
 [tool.pytest.ini_options]
 doctest_optionflags = "NORMALIZE_WHITESPACE NUMBER"
-addopts = "  --cov=dolphin  -n auto --maxprocesses=8 --doctest-modules --randomly-seed=1234 --ignore=scripts --ignore=docs --ignore=data --ignore=pkgs"
+# addopts = "  --cov=dolphin  -n auto --maxprocesses=8 --doctest-modules --randomly-seed=1234 --ignore=scripts --ignore=docs --ignore=data --ignore=pkgs"
+addopts = " --doctest-modules --randomly-seed=1234 --ignore=scripts --ignore=docs --ignore=data --ignore=pkgs"
 filterwarnings = [
   "error",
   # DeprecationWarning thrown in pkg_resources for older numba verions and llvmlite

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ opera-utils>=0.1.5
 pydantic>=2.1
 pymp-pypi>=0.4.5
 pyproj>=3.3
+rasterio>=1.3
 rich>=12.0
 ruamel_yaml>=0.15
 scipy>=1.5

--- a/src/dolphin/_background.py
+++ b/src/dolphin/_background.py
@@ -14,6 +14,13 @@ logger = get_log(__name__)
 
 _DEFAULT_TIMEOUT = 0.5
 
+__all__ = [
+    "BackgroundWorker",
+    "BackgroundReader",
+    "BackgroundWriter",
+    "DummyProcessPoolExecutor",
+]
+
 
 class BackgroundWorker(abc.ABC):
     """Base class for doing work in a background thread.

--- a/src/dolphin/_readers.py
+++ b/src/dolphin/_readers.py
@@ -452,53 +452,6 @@ class BaseStackReader(StackReader):
     def dtype(self):
         return self.readers[0].dtype
 
-    def iter_blocks(
-        self,
-        overlaps: tuple[int, int] = (0, 0),
-        block_shape: tuple[int, int] = (512, 512),
-        skip_empty: bool = True,
-        nodata_mask: Optional[np.ndarray] = None,
-        show_progress: bool = True,
-    ) -> Generator[tuple[np.ndarray, tuple[slice, slice]], None, None]:
-        """Iterate over blocks of the stack.
-
-        Loads all images for one window at a time into memory, while eagerly
-        fetching the next block in the background.
-
-        Parameters
-        ----------
-        overlaps : tuple[int, int], optional
-            Pixels to overlap each block by (rows, cols)
-            By default (0, 0)
-        block_shape : tuple[int, int], optional
-            2D shape of blocks to load at a time.
-            Loads all dates/bands at a time with this shape.
-        skip_empty : bool, optional (default True)
-            Skip blocks that are entirely empty (all NaNs)
-        nodata_mask : bool, optional
-            Optional mask indicating nodata values. If provided, will skip
-            blocks that are entirely nodata.
-            1s are the nodata values, 0s are valid data.
-        show_progress : bool, default=True
-            If true, displays a `rich` ProgressBar.
-
-        Yields
-        ------
-        tuple[np.ndarray, tuple[slice, slice]]
-            Iterator of (data, (slice(row_start, row_stop), slice(col_start, col_stop))
-
-        """
-        loader = EagerLoader(
-            self,
-            block_shape=block_shape,
-            overlaps=overlaps,
-            nodata_mask=nodata_mask,
-            nodata_value=self.nodata_value,
-            skip_empty=skip_empty,
-            show_progress=show_progress,
-        )
-        yield from loader.iter_blocks()
-
 
 @dataclass
 class BinaryStackReader(BaseStackReader):
@@ -885,52 +838,6 @@ class VRTStack(StackReader):
             write_file=False,
             **kwargs,
         )
-
-    def iter_blocks(
-        self,
-        overlaps: tuple[int, int] = (0, 0),
-        block_shape: tuple[int, int] = (512, 512),
-        skip_empty: bool = True,
-        nodata_mask: Optional[np.ndarray] = None,
-        show_progress: bool = True,
-    ) -> Generator[tuple[np.ndarray, tuple[slice, slice]], None, None]:
-        """Iterate over blocks of the stack.
-
-        Loads all images for one window at a time into memory, while eagerly
-        fetching the next block in the background.
-
-        Parameters
-        ----------
-        overlaps : tuple[int, int], optional
-            Pixels to overlap each block by (rows, cols)
-            By default (0, 0)
-        block_shape : tuple[int, int], optional
-            2D shape of blocks to load at a time.
-            Loads all dates/bands at a time with this shape.
-        skip_empty : bool, optional (default True)
-            Skip blocks that are entirely empty (all NaNs)
-        nodata_mask : bool, optional
-            Optional mask indicating nodata values. If provided, will skip
-            blocks that are entirely nodata.
-            1s are the nodata values, 0s are valid data.
-        show_progress : bool, default=True
-            If true, displays a `rich` ProgressBar.
-
-        Yields
-        ------
-        tuple[np.ndarray, tuple[slice, slice]]
-            Iterator of (data, (slice(row_start, row_stop), slice(col_start, col_stop))
-
-        """
-        loader = EagerLoader(
-            self,
-            block_shape=block_shape,
-            overlaps=overlaps,
-            nodata_mask=nodata_mask,
-            skip_empty=skip_empty,
-            show_progress=show_progress,
-        )
-        yield from loader.iter_blocks()
 
     @property
     def shape(self):

--- a/src/dolphin/_readers.py
+++ b/src/dolphin/_readers.py
@@ -479,7 +479,7 @@ class HDF5StackReader(BaseStackReader):
     def from_file_list(
         cls,
         file_list: Sequence[Filename],
-        dset_names=str | Sequence[str],
+        dset_names: str | Sequence[str],
         keep_open: bool = False,
         num_threads: int = 1,
     ) -> HDF5StackReader:

--- a/src/dolphin/_readers.py
+++ b/src/dolphin/_readers.py
@@ -39,7 +39,7 @@ __all__ = [
 if TYPE_CHECKING:
     from builtins import ellipsis
 
-Index = ellipsis | slice | int
+    Index = ellipsis | slice | int
 
 
 @runtime_checkable
@@ -881,6 +881,8 @@ class VRTStack(StackReader):
             if n < 0:
                 n = len(self) + n
             return self.read_stack(band=n + 1, rows=rows, cols=cols)
+        elif n is ...:
+            n = slice(None)
 
         bands = list(range(1, 1 + len(self)))[n]
         if len(bands) == len(self):

--- a/src/dolphin/io.py
+++ b/src/dolphin/io.py
@@ -22,6 +22,7 @@ from pyproj import CRS
 from dolphin._background import _DEFAULT_TIMEOUT, BackgroundReader, BackgroundWriter
 from dolphin._blocks import compute_out_shape, iter_blocks
 from dolphin._log import get_log
+from dolphin._readers import DatasetReader
 from dolphin._types import Bbox, Filename
 from dolphin.utils import gdal_to_numpy_type, numpy_to_gdal_type, progress
 
@@ -764,23 +765,24 @@ class EagerLoader(BackgroundReader):
 
     def __init__(
         self,
-        filename: Filename,
+        reader: DatasetReader,
         block_shape: tuple[int, int],
         overlaps: tuple[int, int] = (0, 0),
         skip_empty: bool = True,
+        nodata_value: Optional[float] = None,
         nodata_mask: Optional[ArrayLike] = None,
         queue_size: int = 1,
         timeout: float = _DEFAULT_TIMEOUT,
         show_progress: bool = True,
     ):
         super().__init__(nq=queue_size, timeout=timeout, name="EagerLoader")
-        self.filename = filename
+        self.reader = reader
         # Set up the generator of ((row_start, row_end), (col_start, col_end))
-        xsize, ysize = get_raster_xysize(filename)
         # convert the slice generator to a list so we have the size
+        nrows, ncols = self.reader.shape[-2:]
         self.slices = list(
             iter_blocks(
-                arr_shape=(ysize, xsize),
+                arr_shape=(nrows, ncols),
                 block_shape=block_shape,
                 overlaps=overlaps,
             )
@@ -789,14 +791,14 @@ class EagerLoader(BackgroundReader):
         self._skip_empty = skip_empty
         self._nodata_mask = nodata_mask
         self._block_shape = block_shape
-        self._nodata = get_raster_nodata(filename)
+        self._nodata = nodata_value
         self._show_progress = show_progress
         if self._nodata is None:
             self._nodata = np.nan
 
     def read(self, rows: slice, cols: slice) -> tuple[np.ndarray, tuple[slice, slice]]:
         logger.debug(f"EagerLoader reading {rows}, {cols}")
-        cur_block = load_gdal(self.filename, rows=rows, cols=cols)
+        cur_block = self.reader[rows, cols]
         return cur_block, (rows, cols)
 
     def iter_blocks(
@@ -834,48 +836,6 @@ class EagerLoader(BackgroundReader):
         self.notify_finished()
 
 
-def get_max_block_shape(
-    filename: Filename, nstack: int, max_bytes: float = 64e6
-) -> tuple[int, int]:
-    """Find a block shape to load from `filename` with memory size < `max_bytes`.
-
-    Attempts to get an integer number of chunks ("tiles" for geotiffs) from the
-    file to avoid partial tiles.
-
-    Parameters
-    ----------
-    filename : str
-        GDAL-readable file name containing 3D dataset.
-    nstack: int
-        Number of bands in dataset.
-    max_bytes : float, optional
-        Target size of memory (in Bytes) for each block.
-        Defaults to 64e6.
-
-    Returns
-    -------
-    tuple[int, int]:
-        (num_rows, num_cols) shape of blocks to load from `vrt_file`
-    """
-    chunk_cols, chunk_rows = get_raster_chunk_size(filename)
-    xsize, ysize = get_raster_xysize(filename)
-    # If it's written by line, load at least 16 lines at a time
-    chunk_cols = min(max(16, chunk_cols), xsize)
-    chunk_rows = min(max(16, chunk_rows), ysize)
-
-    ds = gdal.Open(fspath(filename))
-    shape = (ds.RasterYSize, ds.RasterXSize)
-    # get the size of the data type from the raster
-    nbytes = gdal_to_numpy_type(ds.GetRasterBand(1).DataType).itemsize
-    return _increment_until_max(
-        max_bytes=max_bytes,
-        file_chunk_size=[chunk_rows, chunk_cols],
-        shape=shape,
-        nstack=nstack,
-        bytes_per_pixel=nbytes,
-    )
-
-
 def get_raster_chunk_size(filename: Filename) -> list[int]:
     """Get size the raster's chunks on disk.
 
@@ -888,37 +848,3 @@ def get_raster_chunk_size(filename: Filename) -> list[int]:
             logger.warning(f"Warning: {filename} bands have different block shapes.")
             break
     return block_size
-
-
-def _increment_until_max(
-    max_bytes: float,
-    file_chunk_size: Sequence[int],
-    shape: tuple[int, int],
-    nstack: int,
-    bytes_per_pixel: int = 8,
-) -> tuple[int, int]:
-    """Find size of 3D chunk to load while staying at ~`max_bytes` bytes of RAM."""
-    chunk_rows, chunk_cols = file_chunk_size
-
-    # How many chunks can we fit in max_bytes?
-    chunks_per_block = max_bytes / (
-        (nstack * chunk_rows * chunk_cols) * bytes_per_pixel
-    )
-    num_chunks = [1, 1]
-    cur_block_shape = [chunk_rows, chunk_cols]
-
-    idx = 1  # start incrementing cols
-    while chunks_per_block > 1 and tuple(cur_block_shape) != tuple(shape):
-        # Alternate between adding a row and column chunk by flipping the idx
-        chunk_idx = idx % 2
-        nc = num_chunks[chunk_idx]
-        chunk_size = file_chunk_size[chunk_idx]
-
-        cur_block_shape[chunk_idx] = min(nc * chunk_size, shape[chunk_idx])
-
-        chunks_per_block = max_bytes / (
-            nstack * np.prod(cur_block_shape) * bytes_per_pixel
-        )
-        num_chunks[chunk_idx] += 1
-        idx += 1
-    return cur_block_shape[0], cur_block_shape[1]

--- a/src/dolphin/io.py
+++ b/src/dolphin/io.py
@@ -180,10 +180,11 @@ def format_nc_filename(filename: Filename, ds_name: Optional[str] = None) -> str
         If `ds_name` is not provided for a .h5 or .nc file.
     """
     # If we've already formatted the filename, return it
-    if str(filename).startswith("NETCDF:") or str(filename).startswith("HDF5:"):
-        return str(filename)
+    fname_clean = fspath(filename).lstrip('"').lstrip("'").rstrip('"').rstrip("'")
+    if fname_clean.startswith("NETCDF:") or fname_clean.startswith("HDF5:"):
+        return fspath(filename)
 
-    if not (fspath(filename).endswith(".nc") or fspath(filename).endswith(".h5")):
+    if not (fname_clean.endswith(".nc") or fname_clean.endswith(".h5")):
         return fspath(filename)
 
     # Now we're definitely dealing with an HDF5/NetCDF file

--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -115,15 +115,15 @@ def _get_path_from_gdal_str(name: Filename) -> Path:
 
 def _resolve_gdal_path(gdal_str: Filename) -> Filename:
     """Resolve the file portion of a gdal-openable string to an absolute path."""
-    s = str(gdal_str)
+    s_clean = str(gdal_str).lstrip('"').lstrip("'").rstrip('"').rstrip("'")
     prefixes = ["DERIVED_SUBDATASET", "NETCDF", "HDF"]
-    is_gdal_str = any(s.upper().startswith(pre) for pre in prefixes)
-    file_part = str(_get_path_from_gdal_str(gdal_str))
+    is_gdal_str = any(s_clean.upper().startswith(pre) for pre in prefixes)
+    file_part = str(_get_path_from_gdal_str(s_clean))
 
     # strip quotes to add back in after
     file_part = file_part.strip('"').strip("'")
     file_part_resolved = Path(file_part).resolve()
-    resolved = s.replace(file_part, str(file_part_resolved))
+    resolved = s_clean.replace(file_part, str(file_part_resolved))
     return Path(resolved) if not is_gdal_str else resolved
 
 

--- a/src/dolphin/workflows/ps.py
+++ b/src/dolphin/workflows/ps.py
@@ -88,10 +88,11 @@ def run(
 
     logger.info(f"Creating persistent scatterer file {ps_output}")
     dolphin.ps.create_ps(
-        slc_vrt_file=vrt_stack.outfile,
+        reader=vrt_stack,
         output_file=output_file_list[0],
         output_amp_mean_file=output_file_list[1],
         output_amp_dispersion_file=output_file_list[2],
+        like_filename=vrt_stack.outfile,
         amp_dispersion_threshold=cfg.ps_options.amp_dispersion_threshold,
         block_shape=cfg.worker_settings.block_shape,
     )

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -74,7 +74,8 @@ def run(
             existing_amp = existing_disp = None
 
         ps.create_ps(
-            slc_vrt_file=vrt_stack.outfile,
+            reader=vrt_stack,
+            like_filename=vrt_stack.outfile,
             output_file=ps_output,
             output_amp_mean_file=cfg.ps_options._amp_mean_file,
             output_amp_dispersion_file=cfg.ps_options._amp_dispersion_file,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,12 +223,12 @@ def raster_10_by_20(tmp_path, tiled_raster_100_by_200):
 
 
 @pytest.fixture
-def raster_with_nan(tmpdir, tiled_raster_100_by_200):
+def raster_with_nan(tmp_path, tiled_raster_100_by_200):
     # Raster with one nan pixel
     start_arr = load_gdal(tiled_raster_100_by_200)
     nan_arr = start_arr.copy()
     nan_arr[0, 0] = np.nan
-    output_name = tmpdir / "with_one_nan.tif"
+    output_name = tmp_path / "with_one_nan.tif"
     write_arr(
         arr=nan_arr,
         like_filename=tiled_raster_100_by_200,
@@ -239,9 +239,9 @@ def raster_with_nan(tmpdir, tiled_raster_100_by_200):
 
 
 @pytest.fixture
-def raster_with_nan_block(tmpdir, tiled_raster_100_by_200):
+def raster_with_nan_block(tmp_path, tiled_raster_100_by_200):
     # One full block of 32x32 is nan
-    output_name = tmpdir / "with_nans.tif"
+    output_name = tmp_path / "with_nans.tif"
     nan_arr = load_gdal(tiled_raster_100_by_200)
     nan_arr[:32, :32] = np.nan
     write_arr(
@@ -254,9 +254,9 @@ def raster_with_nan_block(tmpdir, tiled_raster_100_by_200):
 
 
 @pytest.fixture
-def raster_with_zero_block(tmpdir, tiled_raster_100_by_200):
+def raster_with_zero_block(tmp_path, tiled_raster_100_by_200):
     # One full block of 32x32 is nan
-    output_name = tmpdir / "with_zeros.tif"
+    output_name = tmp_path / "with_zeros.tif"
     out_arr = load_gdal(tiled_raster_100_by_200)
     out_arr[:] = 1.0
 

--- a/tests/test_ps.py
+++ b/tests/test_ps.py
@@ -61,7 +61,8 @@ def test_create_ps(tmp_path, vrt_stack):
     amp_dispersion_file = tmp_path / "amp_disp.tif"
     amp_mean_file = tmp_path / "amp_mean.tif"
     dolphin.ps.create_ps(
-        slc_vrt_file=vrt_stack.outfile,
+        reader=vrt_stack,
+        like_filename=vrt_stack.outfile,
         output_amp_dispersion_file=amp_dispersion_file,
         output_amp_mean_file=amp_mean_file,
         output_file=ps_mask_file,
@@ -92,12 +93,12 @@ def test_multilook_ps_file(tmp_path, vrt_stack):
     amp_dispersion_file = tmp_path / "amp_disp.tif"
     amp_mean_file = tmp_path / "amp_mean.tif"
     dolphin.ps.create_ps(
-        slc_vrt_file=vrt_stack.outfile,
+        reader=vrt_stack,
+        like_filename=vrt_stack.outfile,
         output_amp_dispersion_file=amp_dispersion_file,
         output_amp_mean_file=amp_mean_file,
         output_file=ps_mask_file,
     )
-
     output_file = dolphin.ps.multilook_ps_mask(
         strides={"x": 5, "y": 3}, ps_mask_file=ps_mask_file
     )

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -10,6 +10,8 @@ from dolphin._readers import (
     BinaryStackReader,
     HDF5Reader,
     HDF5StackReader,
+    RasterReader,
+    RasterStackReader,
     VRTStack,
     _parse_vrt_file,
 )
@@ -150,6 +152,28 @@ def test_hdf5_stack_read_slices(
     expected = slc_stack[dslice, rslice, cslice]
     assert s.shape == expected.shape
     npt.assert_array_almost_equal(s, expected)
+
+
+# #### RasterReader Tests ####
+
+# We already have raster files in slc_file_list
+
+
+def test_raster_reader(slc_file_list, slc_stack):
+    r = RasterReader(slc_file_list[0])
+    assert r.shape == slc_stack[0].shape
+    assert r.dtype == slc_stack[0].dtype
+    assert r.ndim == 2
+    assert r.shape == (100, 200)
+    assert r.dtype == np.complex64
+
+
+def test_raster_stack_reader(slc_file_list, slc_stack):
+    s = RasterStackReader.from_file_list(slc_file_list)
+    assert s.shape == slc_stack.shape
+    assert len(s) == len(slc_stack) == len(slc_file_list)
+    assert s.ndim == 3
+    assert s.dtype == slc_stack.dtype
 
 
 # #### VRT Tests ####

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -362,11 +362,11 @@ def test_iter_blocks(vrt_stack):
     for b in blocks:
         assert b.shape == (len(vrt_stack), 5, 5)
 
-    loader = EagerLoader(reader=vrt_stack, block_shape=(3, 2))
+    loader = EagerLoader(reader=vrt_stack, block_shape=(5, 2))
     blocks, slices = zip(*list(loader.iter_blocks()))
-    assert len(blocks) == 10
+    assert len(blocks) == 5
     for b in blocks:
-        assert b.shape == (len(vrt_stack), 3, 2)
+        assert b.shape == (len(vrt_stack), 5, 2)
 
 
 def test_tiled_iter_blocks(tmp_path, tiled_file_list):

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -5,10 +6,12 @@ import numpy.testing as npt
 import pytest
 import rasterio as rio
 from osgeo import gdal
+from rasterio.errors import NotGeoreferencedWarning
 
 from dolphin._readers import (
     BinaryReader,
     BinaryStackReader,
+    EagerLoader,
     HDF5Reader,
     HDF5StackReader,
     RasterReader,
@@ -22,6 +25,20 @@ from dolphin.utils import _get_path_from_gdal_str
 
 # Get combinations of slices
 slices_to_test = [slice(None), 1, slice(0, 10, 2)]
+
+
+# Filter rasterio georeferencing warnings
+@pytest.fixture(autouse=True)
+def suppress_not_georeferenced_warning():
+    """
+    Pytest fixture to suppress NotGeoreferencedWarning in tests.
+
+    This fixture automatically applies to all test functions in the module
+    where it's defined, suppressing the specified warning.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=NotGeoreferencedWarning)
+        yield
 
 
 @pytest.fixture(scope="module")
@@ -168,6 +185,7 @@ def raster_reader(slc_file_list, slc_stack):
     assert r.dtype == slc_stack[0].dtype
     assert r.ndim == 2
     assert r.dtype == np.complex64
+    return r
 
 
 class TestRaster:
@@ -208,9 +226,9 @@ class TestRaster:
 @pytest.mark.parametrize("cols", slices_to_test)
 def test_ellipsis_reads(binary_reader, hdf5_reader, raster_reader, rows, cols):
     # Test that the ellipsis works
-    assert binary_reader[...] is binary_reader[()]
-    assert hdf5_reader[...] is hdf5_reader[()]
-    assert raster_reader[...] is raster_reader[()]
+    npt.assert_array_equal(binary_reader[...], binary_reader[()])
+    npt.assert_array_equal(hdf5_reader[...], hdf5_reader[()])
+    npt.assert_array_equal(raster_reader[...], raster_reader[()])
     # Test we can still do rows/cols with a leading ellipsis
     npt.assert_array_equal(binary_reader[..., rows, cols], binary_reader[rows, cols])
     npt.assert_array_equal(hdf5_reader[..., rows, cols], hdf5_reader[rows, cols])
@@ -337,22 +355,25 @@ def test_bad_sizes(slc_file_list, raster_10_by_20):
 
 
 def test_iter_blocks(vrt_stack):
-    blocks, slices = zip(*list(vrt_stack.iter_blocks(block_shape=(5, 5))))
+    loader = EagerLoader(reader=vrt_stack, block_shape=(5, 5))
+    blocks, slices = zip(*list(loader.iter_blocks()))
     # (5, 10) total shape, breaks into 5x5 blocks
     assert len(blocks) == 2
     for b in blocks:
         assert b.shape == (len(vrt_stack), 5, 5)
 
-    blocks, slices = zip(*list(vrt_stack.iter_blocks(block_shape=(1, 2))))
-    assert len(blocks) == 25
+    loader = EagerLoader(reader=vrt_stack, block_shape=(3, 2))
+    blocks, slices = zip(*list(loader.iter_blocks()))
+    assert len(blocks) == 10
     for b in blocks:
-        assert b.shape == (len(vrt_stack), 1, 2)
+        assert b.shape == (len(vrt_stack), 3, 2)
 
 
 def test_tiled_iter_blocks(tmp_path, tiled_file_list):
     outfile = tmp_path / "stack.vrt"
     vrt_stack = VRTStack(tiled_file_list, outfile=outfile)
-    blocks, slices = zip(*list(vrt_stack.iter_blocks(block_shape=(32, 32))))
+    loader = EagerLoader(reader=vrt_stack, block_shape=(32, 32))
+    blocks, slices = zip(*list(loader.iter_blocks()))
     # (100, 200) total shape, breaks into 32x32 blocks
     assert len(blocks) == len(slices) == 28
     for i, b in enumerate(blocks, start=1):
@@ -364,7 +385,8 @@ def test_tiled_iter_blocks(tmp_path, tiled_file_list):
             else:
                 assert b.shape == (len(vrt_stack), 32, 8)
 
-    blocks, slices = zip(*list(vrt_stack.iter_blocks(block_shape=(50, 100))))
+    loader = EagerLoader(reader=vrt_stack, block_shape=(50, 100))
+    blocks, slices = zip(*list(loader.iter_blocks()))
     assert len(blocks) == len(slices) == 4
 
 
@@ -421,3 +443,101 @@ def test_parse_vrt(tmp_path, test_vrt):
         "t087_185684_iw2_20220104.h5",
     ]
     assert sds == "data/VV"
+
+
+class TestEagerLoader:
+    def test_iter_blocks(self, tiled_raster_100_by_200):
+        # Try the whole raster
+        bs = (100, 200)
+        loader = EagerLoader(
+            reader=RasterReader.from_file(tiled_raster_100_by_200), block_shape=bs
+        )
+        # `list` should try to load all at once`
+        block_slice_tuples = list(loader.iter_blocks())
+        assert not loader._thread.is_alive()
+        assert len(block_slice_tuples) == 1
+        blocks, slices = zip(*list(block_slice_tuples))
+        assert blocks[0].shape == (100, 200)
+        rows, cols = slices[0]
+        assert rows == slice(0, 100)
+        assert cols == slice(0, 200)
+
+        # now one block at a time
+        bs = (32, 32)
+        reader = RasterReader.from_file(tiled_raster_100_by_200)
+        loader = EagerLoader(reader=reader, block_shape=bs)
+        blocks, slices = zip(*list(loader.iter_blocks()))
+
+        row_blocks = 100 // 32 + 1
+        col_blocks = 200 // 32 + 1
+        expected_num_blocks = row_blocks * col_blocks
+        assert len(blocks) == expected_num_blocks
+        assert blocks[0].shape == (32, 32)
+        # at the ends, the block_slice_tuples are smaller
+        assert blocks[6].shape == (32, 8)
+        assert blocks[-1].shape == (4, 8)
+
+    def test_iter_blocks_rowcols(self, tiled_raster_100_by_200):
+        # Block size that is a multiple of the raster size
+        reader = RasterReader.from_file(tiled_raster_100_by_200)
+        loader = EagerLoader(reader=reader, block_shape=(10, 20))
+        blocks, slices = zip(*list(loader.iter_blocks()))
+
+        assert blocks[0].shape == (10, 20)
+        for rs, cs in slices:
+            assert rs.stop - rs.start == 10
+            assert cs.stop - cs.start == 20
+        loader.notify_finished()
+
+        # Non-multiple block size
+        reader = RasterReader.from_file(tiled_raster_100_by_200)
+        loader = EagerLoader(reader=reader, block_shape=(32, 32))
+        blocks, slices = zip(*list(loader.iter_blocks()))
+        assert blocks[0].shape == (32, 32)
+        for b, (rs, cs) in zip(blocks, slices):
+            assert b.shape == (rs.stop - rs.start, cs.stop - cs.start)
+        loader.notify_finished()
+
+    def test_iter_nodata(
+        self,
+        raster_with_nan,
+        raster_with_nan_block,
+        raster_with_zero_block,
+        tiled_raster_100_by_200,
+    ):
+        # load one block at a time
+        bs = (100, 200)
+        reader = RasterReader.from_file(tiled_raster_100_by_200)
+        loader = EagerLoader(reader=reader, block_shape=bs)
+        blocks, slices = zip(*list(loader.iter_blocks()))
+        loader.notify_finished()
+
+        bs = (32, 32)
+        row_blocks = 100 // 32 + 1
+        col_blocks = 200 // 32 + 1
+        expected_num_blocks = row_blocks * col_blocks
+        loader = EagerLoader(reader=reader, block_shape=bs)
+        blocks, slices = zip(*list(loader.iter_blocks()))
+        assert len(blocks) == expected_num_blocks
+        assert blocks[0].shape == bs
+
+        # One nan should be fine, will get loaded
+        reader = RasterReader.from_file(raster_with_nan)
+        loader = EagerLoader(reader=reader, block_shape=bs)
+        blocks, slices = zip(*list(loader.iter_blocks()))
+        loader.notify_finished()
+        assert len(blocks) == expected_num_blocks
+
+        # Now check entire block for a skipped block
+        reader = RasterReader.from_file(raster_with_nan_block)
+        loader = EagerLoader(reader=reader, block_shape=bs)
+        blocks, slices = zip(*list(loader.iter_blocks()))
+        loader.notify_finished()
+        assert len(blocks) == expected_num_blocks - 1
+
+        # Now check entire block for a skipped block
+        reader = RasterReader.from_file(raster_with_zero_block)
+        loader = EagerLoader(reader=reader, block_shape=bs)
+        blocks, slices = zip(*list(loader.iter_blocks()))
+        loader.notify_finished()
+        assert len(blocks) == expected_num_blocks - 1


### PR DESCRIPTION
Some timing results on a test where I had

- 80 total rasters, shape of the input stack was `(80, 2160, 3600)`
- Saved in formats
  - `.bin`: flat binary/ENVI
  - `.h5`: HDF5 with gzip
  - `.lzf.h5`: HDF5 with lzf compression
  - `.tif`: geotiff with dolphin default compression options
- reading over all bands of (512, 512) blocks at a time, and summing up the values (just to do something with the data)

HDF5StackReader:
```
(mapping-311) opera-test-data$ python test_read.py --reader-class HDF5StackReader data/*[0-9].h5
              Read times              
┏━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ keep_open ┃ num_threads ┃ time (s) ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ False     │ 1           │ 4.517    │
│ False     │ 3           │ 4.901    │
│ False     │ 10          │ 7.138    │
│ True      │ 1           │ 3.453    │
│ True      │ 3           │ 3.695    │
│ True      │ 10          │ 3.893    │
└───────────┴─────────────┴──────────┘

(mapping-311) opera-test-data$ python test_read.py --reader-class HDF5StackReader data/*[0-9].lzf.h5

              Read times              
┏━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ keep_open ┃ num_threads ┃ time (s) ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ False     │ 1           │ 5.881    │
│ False     │ 3           │ 6.406    │
│ False     │ 10          │ 7.978    │
│ True      │ 1           │ 4.957    │
│ True      │ 3           │ 5.176    │
│ True      │ 10          │ 5.399    │
└───────────┴─────────────┴──────────┘
```
BinaryReader:
```

(mapping-311) opera-test-data$ python test_read.py --reader-class BinaryStackReader data/*[0-9].bin

              Read times              
┏━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ keep_open ┃ num_threads ┃ time (s) ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ False     │ 1           │ 4.196    │
│ False     │ 3           │ 2.668    │
│ False     │ 10          │ 2.584    │
└───────────┴─────────────┴──────────┘
```
Raster:
```
(mapping-311) opera-test-data$ python test_read.py --reader-class RasterStackReader data/*[0-9].bin
              Read times              
┏━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ keep_open ┃ num_threads ┃ time (s) ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ False     │ 1           │ 9.766    │
│ False     │ 3           │ 5.784    │
│ False     │ 10          │ 6.719    │
│ True      │ 1           │ 11.062   │
│ True      │ 3           │ 7.523    │
│ True      │ 10          │ 8.939    │
└───────────┴─────────────┴──────────┘
(mapping-311) opera-test-data$ python test_read.py --reader-class raster data/*[0-9].tif 
             Read times              
┏━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ keep_open ┃ num_threads ┃ time (s) ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ False     │ 1           │ 4.303    │
│ False     │ 3           │ 4.142    │
│ False     │ 10          │ 4.893    │
│ True      │ 1           │ 5.679    │
│ True      │ 3           │ 4.880    │
│ True      │ 10          │ 6.063    │
└───────────┴─────────────┴──────────┘
```

Comparing to the current VRT stack method for reading, there's a pretty wide range of times based on the file format.
Note that the "keep_open" and "num_threads" here dont matter, because i was reading all bands for a block so, which uses `ds.ReadAsArray` to let gdal read all bands. 

For input HDF5 files:
```
# Forcing the `NETCDF:filename:/data` format
┏━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ keep_open ┃ num_threads ┃ time (s) ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ False     │ 1           │ 6.812    │
└───────────┴─────────────┴──────────┘
# Forcing the `HDF5:filename://data` format
              Read times              
┏━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ keep_open ┃ num_threads ┃ time (s) ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ False     │ 1           │ 4.285    │

```
geotiff inputs are much faster, and seem to beat the other readers:
```
              Read times              
┏━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ keep_open ┃ num_threads ┃ time (s) ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ False     │ 1           │ 2.192    │
```
and the binary ENVI files are slower with GDAL (likely from the block shape which doesnt match `(1, ncols)`
```
              Read times              
┏━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ keep_open ┃ num_threads ┃ time (s) ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ False     │ 1           │ 7.649    │
```