### PR TITLE
Fix `merge_images` for strided images

### DIFF
--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -252,6 +252,7 @@ def merge_images(
         srcDS=fspath(merge_output),
         projWin=proj_win,
         resampleAlg=resample_alg,
+        format=driver,
     )
 
     temp_dir.cleanup()

--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -215,7 +215,6 @@ def merge_images(
         target_aligned_pixels=target_aligned_pixels,
         out_bounds=out_bounds,
         out_bounds_epsg=out_bounds_epsg,
-        # strides=strides,
     )
     (xmin, ymin, xmax, ymax) = bounds
     proj_win = (xmin, ymax, xmax, ymin)  # ul_lr = ulx, uly, lrx, lry

--- a/tests/test_stitching.py
+++ b/tests/test_stitching.py
@@ -5,6 +5,7 @@ from make_netcdf import create_test_nc
 from pyproj import CRS
 
 from dolphin import io, stitching
+from dolphin._types import Bbox
 
 
 @pytest.fixture()
@@ -23,7 +24,12 @@ def shifted_slc_files(tmp_path):
     return file_list
 
 
-def test_get_combined_bounds_gt(shifted_slc_files):
+@pytest.fixture()
+def shifted_slc_bounds(tmp_path):
+    return Bbox(-5.5, -4.5, 8.5, 9.5)
+
+
+def test_get_combined_bounds_gt(shifted_slc_files, shifted_slc_bounds):
     # Use the created WGS84 SLC
     bnds = io.get_raster_bounds(shifted_slc_files[0])
     expected_bnds = (-5.5, -4.5, 4.5, 5.5)
@@ -55,8 +61,7 @@ def test_get_combined_bounds_gt(shifted_slc_files):
     # Now combined one: should have the mins as the first two values,
     # and the last two values should be the idx=-1 file
     bnds, nd = stitching.get_combined_bounds_nodata(*shifted_slc_files)
-    expected_bnds = (-5.5, -4.5, 8.5, 9.5)
-    assert bnds == expected_bnds
+    assert bnds == shifted_slc_bounds
 
 
 def test_get_combined_bounds_gt_different_proj(
@@ -92,3 +97,38 @@ def test_get_mode_projection(slc_file_list_nc, slc_file_list_nc_wgs84):
         slc_file_list_nc[0:1] + slc_file_list_nc_wgs84[0:2],
     )
     assert CRS.from_user_input(p) == epsg4326
+
+
+def test_merge_images(tmp_path, shifted_slc_files, shifted_slc_bounds):
+    outfile = tmp_path / "stitched.tif"
+    stitching.merge_images(shifted_slc_files, outfile, target_aligned_pixels=False)
+
+    assert io.get_raster_bounds(outfile) == shifted_slc_bounds
+
+    # The target aligned pixels option makes the bounds a multiple of dx/dy
+    # which is 1.0/1.0 here
+    outfile = tmp_path / "stitched_tap.tif"
+    expected_bounds_tap = Bbox(-6.0, -5.0, 9.0, 10.0)
+    stitching.merge_images(shifted_slc_files, outfile)
+
+    assert io.get_raster_bounds(outfile) == expected_bounds_tap
+
+
+def test_merge_images_strided(tmp_path, shifted_slc_files, shifted_slc_bounds):
+    strides = {"x": 2, "y": 3}
+    outfile = tmp_path / "stitched.tif"
+    stitching.merge_images(
+        shifted_slc_files, outfile, target_aligned_pixels=False, strides=strides
+    )
+
+    assert io.get_raster_bounds(outfile) == shifted_slc_bounds
+
+    # The target aligned pixels option makes the bounds a multiple of dx/dy
+    # which is 1.0/1.0 here
+    outfile = tmp_path / "stitched_tap.tif"
+    expected_bounds_tap = Bbox(-6.0, -5.0, 9.0, 10.0)
+    stitching.merge_images(
+        shifted_slc_files, outfile, target_aligned_pixels=True, strides=strides
+    )
+
+    assert io.get_raster_bounds(outfile) == expected_bounds_tap

--- a/tests/test_stitching.py
+++ b/tests/test_stitching.py
@@ -103,32 +103,41 @@ def test_merge_images(tmp_path, shifted_slc_files, shifted_slc_bounds):
     outfile = tmp_path / "stitched.tif"
     stitching.merge_images(shifted_slc_files, outfile, target_aligned_pixels=False)
 
-    assert io.get_raster_bounds(outfile) == shifted_slc_bounds
+    b = io.get_raster_bounds(outfile)
+    assert b == shifted_slc_bounds
 
     # The target aligned pixels option makes the bounds a multiple of dx/dy
     # which is 1.0/1.0 here
     outfile = tmp_path / "stitched_tap.tif"
-    expected_bounds_tap = Bbox(-6.0, -5.0, 9.0, 10.0)
-    stitching.merge_images(shifted_slc_files, outfile)
+    # Now the top/bottom must divide by 3, and left/right divide by 2
+    stitching.merge_images(shifted_slc_files, outfile, target_aligned_pixels=True)
 
-    assert io.get_raster_bounds(outfile) == expected_bounds_tap
+    b = io.get_raster_bounds(outfile)
+    expected_bounds_tap = Bbox(-6.0, -5.0, 9.0, 10.0)
+    assert b == expected_bounds_tap
 
 
 def test_merge_images_strided(tmp_path, shifted_slc_files, shifted_slc_bounds):
     strides = {"x": 2, "y": 3}
     outfile = tmp_path / "stitched.tif"
     stitching.merge_images(
-        shifted_slc_files, outfile, target_aligned_pixels=False, strides=strides
+        shifted_slc_files,
+        outfile,
+        target_aligned_pixels=False,
+        out_bounds=shifted_slc_bounds,
+        strides=strides,
     )
 
-    assert io.get_raster_bounds(outfile) == shifted_slc_bounds
+    b = io.get_raster_bounds(outfile)
+    assert b == shifted_slc_bounds
 
     # The target aligned pixels option makes the bounds a multiple of dx/dy
     # which is 1.0/1.0 here
     outfile = tmp_path / "stitched_tap.tif"
-    expected_bounds_tap = Bbox(-6.0, -5.0, 9.0, 10.0)
+    expected_bounds_tap = Bbox(-6.0, -6.0, 10.0, 12.0)
     stitching.merge_images(
         shifted_slc_files, outfile, target_aligned_pixels=True, strides=strides
     )
 
-    assert io.get_raster_bounds(outfile) == expected_bounds_tap
+    b = io.get_raster_bounds(outfile)
+    assert b == expected_bounds_tap


### PR DESCRIPTION
Two changes need to fix this:
1. we were passing `strides` to `get_combined_bounds_nodata`, even thought we already used it in `get_downsampled_vrts`. this meant it was double counting the strided output resolution, leading to that weird rounding error in @taliboliver 's example
2. Now we do a `gdal_translate` after merging, since `gdal_merge` has no resampling algorithm to guarantee the output bounds.