### PR TITLE
include both tiff and hdf5 for compressed SLC format

### DIFF
--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -362,8 +362,12 @@ class MiniStackPlanner(BaseStack):
             cur_slice = slice(full_stack_idx, full_stack_idx + ministack_size)
             cur_files = list(self.file_list[cur_slice]).copy()
             cur_dates = list(self.dates[cur_slice]).copy()
-
-            comp_slc_files = [c.path for c in compressed_slc_infos]
+            
+            # Read compressed*.tif files and if they do not exist use the compressed*.h5
+            # *.h5 files are inputs for disp-s1
+            comp_slc_files = [c.path for c in compressed_slc_infos if c.path.exists()]
+            if len(comp_slc_files) == 0:
+                comp_slc_files = self.compressed_slc_file_list
             # Add the existing compressed SLC files to the start, but
             # limit the num comp slcs `max_num_compressed`
             cur_comp_slc_files = comp_slc_files[-self.max_num_compressed :]

--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -362,12 +362,12 @@ class MiniStackPlanner(BaseStack):
             cur_slice = slice(full_stack_idx, full_stack_idx + ministack_size)
             cur_files = list(self.file_list[cur_slice]).copy()
             cur_dates = list(self.dates[cur_slice]).copy()
-            
+
             # Read compressed*.tif files and if they do not exist use the compressed*.h5
             # *.h5 files are inputs for disp-s1
             comp_slc_files = [c.path for c in compressed_slc_infos if c.path.exists()]
             if len(comp_slc_files) == 0:
-                comp_slc_files = self.compressed_slc_file_list
+                comp_slc_files = [Path(c) for c in self.compressed_slc_file_list]
             # Add the existing compressed SLC files to the start, but
             # limit the num comp slcs `max_num_compressed`
             cur_comp_slc_files = comp_slc_files[-self.max_num_compressed :]

--- a/src/dolphin/workflows/config/_displacement.py
+++ b/src/dolphin/workflows/config/_displacement.py
@@ -29,6 +29,7 @@ from ._common import (
 
 __all__ = [
     "DisplacementWorkflow",
+    "CorrectionOptions",
 ]
 
 logger = get_log(__name__)


### PR DESCRIPTION
There was a bug in disp-s1 where it only looked for compressed*.tif files while in the config, the compressed SLCs where given in hdf5 format. 