### PR TITLE
Use `.int.tif` for default stitched interferograms

### DIFF
--- a/src/dolphin/interferogram.py
+++ b/src/dolphin/interferogram.py
@@ -634,8 +634,8 @@ def estimate_correlation_from_phase(
 def estimate_interferometric_correlations(
     ifg_paths: Sequence[Filename],
     window_size: tuple[int, int],
-    out_driver: str = "ENVI",
-    out_suffix: str = ".cor",
+    out_driver: str = "GTiff",
+    out_suffix: str = ".cor.tif",
 ) -> list[Path]:
     """Estimate correlations for a sequence of interferograms.
 
@@ -648,9 +648,9 @@ def estimate_interferometric_correlations(
     window_size : tuple[int, int]
         (row, column) size of window to use for estimate
     out_driver : str, optional
-        Name of output GDAL driver, by default "ENVI"
+        Name of output GDAL driver, by default "GTiff"
     out_suffix : str, optional
-        File suffix to use for correlation files, by default ".cor"
+        File suffix to use for correlation files, by default ".cor.tif"
 
     Returns
     -------

--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -27,13 +27,13 @@ def merge_by_date(
     image_file_list: Iterable[Filename],
     file_date_fmt: str = DEFAULT_DATETIME_FORMAT,
     output_dir: Filename = ".",
-    driver: str = "ENVI",
-    output_suffix: str = ".int",
+    driver: str = "GTiff",
+    output_suffix: str = ".int.tif",
     out_nodata: Optional[float] = 0,
     in_nodata: Optional[float] = None,
     out_bounds: Optional[Bbox] = None,
     out_bounds_epsg: Optional[int] = None,
-    options: Optional[Sequence[str]] = io.DEFAULT_ENVI_OPTIONS,
+    options: Optional[Sequence[str]] = io.DEFAULT_TIFF_OPTIONS,
     overwrite: bool = False,
 ) -> dict[tuple[datetime, ...], Path]:
     """Group images from the same datetime and merge into one image per datetime.
@@ -62,7 +62,8 @@ def merge_by_date(
         EPSG code for the `out_bounds`.
         If not provided, assumed to match the projections of `file_list`.
     options : Optional[Sequence[str]]
-        Driver-specific creation options passed to GDAL. Default is ["SUFFIX=ADD"]
+        Driver-specific creation options passed to GDAL.
+        Default is [dolphin.io.DEFAULT_TIFF_OPTIONS][].
     overwrite : bool
         Overwrite existing files. Default is False.
 
@@ -117,13 +118,13 @@ def merge_images(
     out_bounds: Optional[Bbox] = None,
     out_bounds_epsg: Optional[int] = None,
     strides: Optional[dict[str, int]] = None,
-    driver: str = "ENVI",
+    driver: str = "GTiff",
     out_nodata: Optional[float] = 0,
     out_dtype: Optional[DTypeLike] = None,
     in_nodata: Optional[float] = None,
     resample_alg: str = "lanczos",
     overwrite: bool = False,
-    options: Optional[Sequence[str]] = io.DEFAULT_ENVI_OPTIONS,
+    options: Optional[Sequence[str]] = io.DEFAULT_TIFF_OPTIONS,
     create_only: bool = False,
 ) -> None:
     """Combine multiple SLC images on the same date into one image.
@@ -152,7 +153,7 @@ def merge_images(
     strides : dict[str, int]
         subsample factor: {"x": x strides, "y": y strides}
     driver : str
-        GDAL driver to use for output file. Default is ENVI.
+        GDAL driver to use for output file. Default is GTiff.
     out_nodata : Optional[float | str]
         Nodata value to use for output file. Default is 0.
     out_dtype : Optional[DTypeLike]
@@ -166,7 +167,8 @@ def merge_images(
     overwrite : bool
         Overwrite existing files. Default is False.
     options : Optional[Sequence[str]]
-        Driver-specific creation options passed to GDAL. Default is ["SUFFIX=ADD"]
+        Driver-specific creation options passed to GDAL.
+        Default is [dolphin.io.DEFAULT_TIFF_OPTIONS][].
     create_only : bool
         If True, creates an empty output file, does not write data. Default is False.
     """

--- a/src/dolphin/workflows/stitching_bursts.py
+++ b/src/dolphin/workflows/stitching_bursts.py
@@ -65,7 +65,8 @@ def run(
         image_file_list=ifg_file_list,
         file_date_fmt=file_date_fmt,
         output_dir=stitched_ifg_dir,
-        output_suffix=".int",
+        output_suffix=".int.tif",
+        driver="GTiff",
         out_bounds=out_bounds,
         out_bounds_epsg=output_options.bounds_epsg,
     )

--- a/tests/test_stitching.py
+++ b/tests/test_stitching.py
@@ -141,3 +141,26 @@ def test_merge_images_strided(tmp_path, shifted_slc_files, shifted_slc_bounds):
 
     b = io.get_raster_bounds(outfile)
     assert b == expected_bounds_tap
+
+
+@pytest.mark.parametrize("buffer", [0, 1.5])
+@pytest.mark.parametrize("strides", [{"x": 1, "y": 1}, {"x": 3, "y": 2}])
+def test_merge_images_specify_bounds(
+    tmp_path, strides, buffer, shifted_slc_files, shifted_slc_bounds
+):
+    from shapely.geometry import box
+
+    outfile = tmp_path / "stitched.tif"
+
+    buffered_box = box(*shifted_slc_bounds).buffer(buffer)
+    buffered_bounds = buffered_box.bounds
+    stitching.merge_images(
+        shifted_slc_files,
+        outfile,
+        target_aligned_pixels=False,
+        out_bounds=buffered_bounds,
+        strides=strides,
+    )
+
+    b = io.get_raster_bounds(outfile)
+    assert b == buffered_bounds

--- a/tests/test_workflows_displacement.py
+++ b/tests/test_workflows_displacement.py
@@ -105,8 +105,8 @@ def test_stack_with_compressed(opera_slc_files, tmpdir):
 
         # Now the results should be the same (for the file names)
         # check the ifg folders
-        ifgs1 = sorted((p1 / "interferograms").glob("*.int"))
-        ifgs2 = sorted((p2 / "interferograms").glob("*.int"))
+        ifgs1 = sorted((p1 / "interferograms").glob("*.int.tif"))
+        ifgs2 = sorted((p2 / "interferograms").glob("*.int.tif"))
         assert len(ifgs1) > 0
         assert [f.name for f in ifgs1] == [f.name for f in ifgs2]
 
@@ -117,7 +117,7 @@ def test_separate_workflow_runs(slc_file_list, tmp_path):
     """
     p_all = tmp_path / "all"
     run_displacement_stack(p_all, slc_file_list, ministack_size=10)
-    all_ifgs = sorted((p_all / "interferograms").glob("*.int"))
+    all_ifgs = sorted((p_all / "interferograms").glob("*.int.tif"))
     assert len(all_ifgs) == 29
 
     p1 = tmp_path / Path("first")
@@ -129,7 +129,7 @@ def test_separate_workflow_runs(slc_file_list, tmp_path):
     run_displacement_stack(p1, file_batches[0])
     new_comp_slcs1 = sorted((p1 / "linked_phase").glob("compressed_*"))
     assert len(new_comp_slcs1) == 1
-    ifgs1 = sorted((p1 / "interferograms").glob("*.int"))
+    ifgs1 = sorted((p1 / "interferograms").glob("*.int.tif"))
     assert len(ifgs1) == 9
 
     p2 = tmp_path / Path("second")
@@ -137,13 +137,13 @@ def test_separate_workflow_runs(slc_file_list, tmp_path):
     run_displacement_stack(p2, files2)
     new_comp_slcs2 = sorted((p2 / "linked_phase").glob("compressed_*"))
     assert len(new_comp_slcs2) == 1
-    ifgs2 = sorted((p2 / "interferograms").glob("*.int"))
+    ifgs2 = sorted((p2 / "interferograms").glob("*.int.tif"))
     assert len(ifgs2) == 10
 
     p3 = tmp_path / Path("third")
     files3 = new_comp_slcs1 + new_comp_slcs2 + file_batches[2]
     run_displacement_stack(p3, files3)
-    ifgs3 = sorted((p3 / "interferograms").glob("*.int"))
+    ifgs3 = sorted((p3 / "interferograms").glob("*.int.tif"))
     assert len(ifgs3) == 10
 
     all_ifgs_names = [f.name for f in all_ifgs]
@@ -156,7 +156,7 @@ def test_separate_workflow_runs(slc_file_list, tmp_path):
     p3_b = tmp_path / Path("third")
     files3_b = new_comp_slcs2 + file_batches[2]
     run_displacement_stack(p3_b, files3_b)
-    ifgs3_b = sorted((p3_b / "interferograms").glob("*.int"))
+    ifgs3_b = sorted((p3_b / "interferograms").glob("*.int.tif"))
     assert len(ifgs3_b) == 10
     # Names should be the same as the previous run
     assert [f.name for f in ifgs3_b] == [f.name for f in ifgs3]


### PR DESCRIPTION
I had initially set it to use ENVI format (with ".int" and ".cor" as the extensions) so that you could run the standalone snaphu right on the outputs, as it needs files in the flat-binary format. Now that https://github.com/isce-framework/snaphu-py exists, we might as well use a format with some compression.
As a bonus, this will also make it easier to browse outputs after running `gdaladdo` on the interferograms/correlations