### PR TITLE
use `model_post_init` instead of overriding `__init__`

### DIFF
--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -382,10 +382,8 @@ class WorkflowBase(YamlModel):
     # Stores the list of directories to be created by the workflow
     _directory_list: list[Path] = PrivateAttr(default_factory=list)
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def model_post_init(self, _context: Any) -> None:
         """After validation, set up properties for use during workflow run."""
-        super().__init__(*args, **kwargs)
-
         # Ensure outputs from workflow steps are within work directory.
         if not self.keep_paths_relative:
             # Save all directories as absolute paths

--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -382,8 +382,9 @@ class WorkflowBase(YamlModel):
     # Stores the list of directories to be created by the workflow
     _directory_list: list[Path] = PrivateAttr(default_factory=list)
 
-    def model_post_init(self, _context: Any) -> None:
+    def model_post_init(self, __context: Any) -> None:
         """After validation, set up properties for use during workflow run."""
+        super().model_post_init(__context)
         # Ensure outputs from workflow steps are within work directory.
         if not self.keep_paths_relative:
             # Save all directories as absolute paths

--- a/src/dolphin/workflows/config/_displacement.py
+++ b/src/dolphin/workflows/config/_displacement.py
@@ -179,8 +179,9 @@ class DisplacementWorkflow(WorkflowBase):
 
         return self
 
-    def model_post_init(self, _context: Any) -> None:
+    def model_post_init(self, __context: Any) -> None:
         """After validation, set up properties for use during workflow run."""
+        super().model_post_init(__context)
         # Ensure outputs from workflow steps are within work directory.
         if not self.keep_paths_relative:
             # Resolve all CSLC paths:

--- a/src/dolphin/workflows/config/_displacement.py
+++ b/src/dolphin/workflows/config/_displacement.py
@@ -179,10 +179,8 @@ class DisplacementWorkflow(WorkflowBase):
 
         return self
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def model_post_init(self, _context: Any) -> None:
         """After validation, set up properties for use during workflow run."""
-        super().__init__(*args, **kwargs)
-
         # Ensure outputs from workflow steps are within work directory.
         if not self.keep_paths_relative:
             # Resolve all CSLC paths:

--- a/src/dolphin/workflows/config/_displacement.py
+++ b/src/dolphin/workflows/config/_displacement.py
@@ -198,6 +198,13 @@ class DisplacementWorkflow(WorkflowBase):
             "unwrap_options",
         ]:
             opts = getattr(self, step)
+            if isinstance(opts, dict):
+                # If this occurs, we are printing the schema.
+                # Using newer pydantic `model_construct`, this would be a dict,
+                # instead of an object.
+                # We don't care about the subsequent logic here
+                return
+
             if opts._directory.parent != work_dir:
                 opts._directory = work_dir / opts._directory
             if not self.keep_paths_relative:

--- a/src/dolphin/workflows/config/_ps.py
+++ b/src/dolphin/workflows/config/_ps.py
@@ -50,10 +50,8 @@ class PsWorkflow(WorkflowBase):
         _read_file_list_or_glob
     )
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def model_post_init(self, _context: Any) -> None:
         """After validation, set up properties for use during workflow run."""
-        super().__init__(*args, **kwargs)
-
         # Ensure outputs from workflow steps are within work directory.
         if not self.keep_paths_relative:
             # Resolve all CSLC paths:

--- a/src/dolphin/workflows/config/_ps.py
+++ b/src/dolphin/workflows/config/_ps.py
@@ -50,8 +50,9 @@ class PsWorkflow(WorkflowBase):
         _read_file_list_or_glob
     )
 
-    def model_post_init(self, _context: Any) -> None:
+    def model_post_init(self, __context: Any) -> None:
         """After validation, set up properties for use during workflow run."""
+        super().model_post_init(__context)
         # Ensure outputs from workflow steps are within work directory.
         if not self.keep_paths_relative:
             # Resolve all CSLC paths:

--- a/src/dolphin/workflows/config/_unwrapping.py
+++ b/src/dolphin/workflows/config/_unwrapping.py
@@ -51,8 +51,9 @@ class UnwrappingWorkflow(WorkflowBase):
         _read_file_list_or_glob
     )
 
-    def model_post_init(self, _context: Any) -> None:
+    def model_post_init(self, __context: Any) -> None:
         """After validation, set up properties for use during workflow run."""
+        super().model_post_init(__context)
         # Ensure outputs from workflow steps are within work directory.
         if not self.keep_paths_relative:
             # Resolve all CSLC paths:

--- a/src/dolphin/workflows/config/_unwrapping.py
+++ b/src/dolphin/workflows/config/_unwrapping.py
@@ -51,10 +51,8 @@ class UnwrappingWorkflow(WorkflowBase):
         _read_file_list_or_glob
     )
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def model_post_init(self, _context: Any) -> None:
         """After validation, set up properties for use during workflow run."""
-        super().__init__(*args, **kwargs)
-
         # Ensure outputs from workflow steps are within work directory.
         if not self.keep_paths_relative:
             # Resolve all CSLC paths:

--- a/src/dolphin/workflows/single.py
+++ b/src/dolphin/workflows/single.py
@@ -267,6 +267,7 @@ def run_wrapped_phase_single(
                 out_cols.start,
             )
 
+    loader.notify_finished()
     # Block until all the writers for this ministack have finished
     logger.info(f"Waiting to write {writer.num_queued} blocks of data.")
     writer.notify_finished()


### PR DESCRIPTION
Earlier version of pydantic didn't have this.
Currently overriding `__init__` loses the type info:
![image](https://github.com/isce-framework/dolphin/assets/8291800/20c3fecf-e8ee-4673-ac2c-9da87795c859)

Now we have them when creating new objects:
![image](https://github.com/isce-framework/dolphin/assets/8291800/f5aebc4f-9b1e-411f-a571-a97fd684ef2a)
