### PR TITLE
Apply `out_bounds` during stitching even if only 1 image exists

### DIFF
--- a/src/dolphin/interferogram.py
+++ b/src/dolphin/interferogram.py
@@ -675,7 +675,6 @@ def estimate_interferometric_correlations(
             output_name=cor_path,
             like_filename=ifg_path,
             driver=out_driver,
-            options=io.DEFAULT_ENVI_OPTIONS,
         )
     return corr_paths
 

--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -182,7 +182,7 @@ def merge_images(
             logger.info(f"Overwrite=True: removing {outfile}")
             Path(outfile).unlink()
 
-    if len(file_list) == 1:
+    if len(file_list) == 1 and out_bounds is None:
         logger.info("Only one image, no stitching needed")
         logger.info(f"Copying {file_list[0]} to {outfile} and zeroing nodata values.")
         _copy_set_nodata(

--- a/tests/test_stitching.py
+++ b/tests/test_stitching.py
@@ -164,3 +164,33 @@ def test_merge_images_specify_bounds(
 
     b = io.get_raster_bounds(outfile)
     assert b == buffered_bounds
+
+
+def test_merge_images_one_image_out_bounds_specified(
+    tmp_path, shifted_slc_files, shifted_slc_bounds
+):
+    from shapely.geometry import box
+
+    outfile = tmp_path / "stitched.tif"
+
+    buffered_box = box(*shifted_slc_bounds).buffer(1.5)
+    buffered_bounds = buffered_box.bounds
+
+    # only grab the first image
+    # without specifying bounds, this should not work
+    stitching.merge_images(shifted_slc_files[:1], outfile)
+
+    b = io.get_raster_bounds(outfile)
+    assert b != buffered_bounds
+
+    outfile2 = tmp_path / "stitched_with_bounds.tif"
+    # after specifying bounds, this should work
+    stitching.merge_images(
+        shifted_slc_files[:1],
+        outfile2,
+        target_aligned_pixels=False,
+        out_bounds=buffered_bounds,
+    )
+
+    b = io.get_raster_bounds(outfile2)
+    assert b == buffered_bounds


### PR DESCRIPTION
Should close #204


Testing on 2 bursts, where
```
$ grep -c t042_088905_iw1 dolphin_config.yaml
12
$ grep -c t042_088906_iw1 dolphin_config.yaml
3
$
```

Before:
```
$ shape interferograms/*.int.tif
interferograms/20221119_20221201.int.tif
1 2222,3524
interferograms/20221119_20221213.int.tif
1 2222,3524
interferograms/20221119_20230106.int.tif
1 1613,3253
interferograms/20221119_20230118.int.tif
1 1613,3253
....
```

After PR:
<details>

```
$ shape interferograms/*.int.tif
interferograms/20221119_20221201.int.tif
1 2222,3524
interferograms/20221119_20221213.int.tif
1 2222,3524
interferograms/20221119_20230106.int.tif
1 2222,3524
interferograms/20221119_20230118.int.tif
1 2222,3524
interferograms/20221119_20230130.int.tif
1 2222,3524
interferograms/20221119_20230211.int.tif
1 2222,3524
interferograms/20221119_20230223.int.tif
1 2222,3524
interferograms/20221119_20230307.int.tif
1 2222,3524
interferograms/20221119_20230319.int.tif
1 2222,3524
interferograms/20221119_20230331.int.tif
1 2222,3524
interferograms/20221119_20230412.int.tif
1 2222,3524
```

</details>