### PR TITLE
Allow `None` or `int` for `ntiles`/`downsample_factor`

### DIFF
--- a/src/dolphin/_overviews.py
+++ b/src/dolphin/_overviews.py
@@ -85,7 +85,7 @@ def create_image_overviews(
     flags = gdal.GA_Update if not external else gdal.GA_ReadOnly
     ds = gdal.Open(fspath(file_path), flags)
     if ds.GetRasterBand(1).GetOverviewCount() > 0:
-        logger.info("%s already has overviews. Skipping.")
+        logger.info("%s already has overviews. Skipping.", file_path)
         return
 
     gdal.SetConfigOption("COMPRESS_OVERVIEW", compression)

--- a/src/dolphin/phase_link/_core.py
+++ b/src/dolphin/phase_link/_core.py
@@ -277,7 +277,7 @@ def run_cpl(
     avg_coh : np.ndarray | None
         The average coherence of each row of the coherence matrix,
         if requested.
-        shape = (ncls, out_rows, out_cols)
+        shape = (nslc, out_rows, out_cols)
 
     """
     C_arrays = covariance.estimate_stack_covariance(
@@ -303,7 +303,7 @@ def run_cpl(
     else:
         avg_coh = None
 
-    # Reshape the (rows, cols, ncls) output to be same as input stack
+    # Reshape the (rows, cols, nslcs) output to be same as input stack
     cpx_phase_reshaped = jnp.moveaxis(cpx_phase, -1, 0)
     return PhaseLinkOutput(
         cpx_phase_reshaped, temp_coh, eigenvalues, estimator, avg_coh

--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -204,6 +204,15 @@ class UnwrapOptions(BaseModel, extra="forbid"):
         description="Statistical cost mode method for SNAPHU.",
     )
 
+    @field_validator("ntiles", "downsample_factor", mode="before")
+    @classmethod
+    def _to_tuple(cls, v):
+        if v is None:
+            return (1, 1)
+        elif isinstance(v, int):
+            return (v, v)
+        return v
+
 
 class WorkerSettings(BaseModel, extra="forbid"):
     """Settings for controlling CPU/GPU settings and parallelism."""


### PR DESCRIPTION
Also fixes overviews log formatting