### PR TITLE
Better nodata/mask handling in `dolphin.unwrap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # [Unreleased](https://github.com/isce-framework/dolphin/compare/v0.13.0...main)
 
+# [0.14.1](https://github.com/isce-framework/dolphin/compare/v0.13.0...main) - 2024-02-15
+
+**Fixed**
+
+- Changed snaphu-py tile defaults to avoid max secondary arcs error in #233
+- Fixed `linalg.norm`` to be pixelwise in `process_coherence_matrices` in #234
+
+
+# [0.14.0](https://github.com/isce-framework/dolphin/compare/v0.13.0...main) - 2024-02-13
+
 **Fixed**
 - Temporal coherence and eigenvalue rasters were switched in their naming
 - Output a better `estimator` raster to see where we switched to EVD

--- a/src/dolphin/unwrap/_constants.py
+++ b/src/dolphin/unwrap/_constants.py
@@ -1,2 +1,9 @@
+from typing import Final
+
 CONNCOMP_SUFFIX = ".unw.conncomp.tif"
 UNW_SUFFIX = ".unw.tif"
+
+UINT16_MAX: Final = 65535
+
+DEFAULT_CCL_NODATA: Final = UINT16_MAX
+DEFAULT_UNW_NODATA: Final = 0

--- a/src/dolphin/unwrap/_isce3.py
+++ b/src/dolphin/unwrap/_isce3.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from os import fspath
+from pathlib import Path
+
+import numpy as np
+
+from dolphin import io
+from dolphin._log import get_log
+from dolphin._types import Filename
+from dolphin.utils import full_suffix
+from dolphin.workflows import UnwrapMethod
+
+from ._constants import CONNCOMP_SUFFIX
+from ._utils import _redirect_unwrapping_log, _zero_from_mask
+
+logger = get_log(__name__)
+
+__all__ = ["unwrap_isce3"]
+
+
+def unwrap_isce3(
+    ifg_filename: Filename,
+    corr_filename: Filename,
+    unw_filename: Filename,
+    mask_file: Filename | None = None,
+    unwrap_method: UnwrapMethod = UnwrapMethod.PHASS,
+    zero_where_masked: bool = False,
+) -> tuple[Path, Path]:
+    """Unwrap a single interferogram using snaphu, isce3, or tophu.
+
+    Parameters
+    ----------
+    ifg_filename : Filename
+        Path to input interferogram.
+    corr_filename : Filename
+        Path to input correlation file.
+    unw_filename : Filename
+        Path to output unwrapped phase file.
+    mask_file : Filename, optional
+        Path to binary byte mask file, by default None.
+        Assumes that 1s are valid pixels and 0s are invalid.
+    zero_where_masked : bool, optional
+        Set wrapped phase/correlation to 0 where mask is 0 before unwrapping.
+        If not mask is provided, this is ignored.
+        By default True.
+    unwrap_method : UnwrapMethod or str, optional, default = "phass"
+        Choice of unwrapping algorithm to use.
+        Choices: {"icu", "phass"} (snaphu is done by snaphu_pu)
+
+    Returns
+    -------
+    unw_path : Path
+        Path to output unwrapped phase file.
+    conncomp_path : Path
+        Path to output connected component label file.
+
+    """
+    # Now we're using PHASS or ICU within isce3
+    from isce3.io import Raster
+    from isce3.unwrap import ICU, Phass
+
+    shape = io.get_raster_xysize(ifg_filename)[::-1]
+    corr_shape = io.get_raster_xysize(corr_filename)[::-1]
+    if shape != corr_shape:
+        msg = f"correlation {corr_shape} and interferogram {shape} shapes don't match"
+        raise ValueError(msg)
+
+    ifg_raster = Raster(fspath(ifg_filename))
+    corr_raster = Raster(fspath(corr_filename))
+    UNW_SUFFIX = full_suffix(unw_filename)
+
+    # Get the driver based on the output file extension
+    if Path(unw_filename).suffix == ".tif":
+        driver = "GTiff"
+        opts = list(io.DEFAULT_TIFF_OPTIONS)
+    else:
+        driver = "ENVI"
+        opts = list(io.DEFAULT_ENVI_OPTIONS)
+
+    # Create output rasters for unwrapped phase & connected component labels.
+    # Writing with `io.write_arr` because isce3 doesn't have creation options
+    io.write_arr(
+        arr=None,
+        output_name=unw_filename,
+        driver=driver,
+        like_filename=ifg_filename,
+        dtype=np.float32,
+        options=opts,
+    )
+    conncomp_filename = str(unw_filename).replace(UNW_SUFFIX, CONNCOMP_SUFFIX)
+    io.write_arr(
+        arr=None,
+        output_name=conncomp_filename,
+        driver="GTiff",
+        dtype=np.uint32,
+        like_filename=ifg_filename,
+        options=io.DEFAULT_TIFF_OPTIONS,
+    )
+
+    # The different raster classes have different APIs, so we need to
+    # create the raster objects differently.
+    unw_raster = Raster(fspath(unw_filename), True)
+    conncomp_raster = Raster(fspath(conncomp_filename), True)
+
+    _redirect_unwrapping_log(unw_filename, unwrap_method.value)
+
+    if zero_where_masked and mask_file is not None:
+        logger.info(f"Zeroing phase/corr of pixels masked in {mask_file}")
+        zeroed_ifg_file, zeroed_corr_file = _zero_from_mask(
+            ifg_filename, corr_filename, mask_file
+        )
+        corr_raster = Raster(fspath(zeroed_corr_file))
+        ifg_raster = Raster(fspath(zeroed_ifg_file))
+
+    logger.info(
+        f"Unwrapping size {(ifg_raster.length, ifg_raster.width)} {ifg_filename} to"
+        f" {unw_filename} using {unwrap_method.value}"
+    )
+    if unwrap_method == UnwrapMethod.PHASS:
+        # TODO: expose the configuration for phass?
+        # If we ever find cases where changing help, then yes we should
+        # coherence_thresh: float = 0.2
+        # good_coherence: float = 0.7
+        # min_region_size: int = 200
+        unwrapper = Phass()
+    else:
+        unwrapper = ICU(buffer_lines=shape[0])
+
+    unwrapper.unwrap(
+        unw_raster,
+        conncomp_raster,
+        ifg_raster,
+        corr_raster,
+    )
+
+    del unw_raster, conncomp_raster
+    return Path(unw_filename), Path(conncomp_filename)

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -22,7 +22,8 @@ def unwrap_snaphu_py(
     nproc: int = 1,
     mask_file: Filename | None = None,
     zero_where_masked: bool = False,
-    nodata: str | float | None = None,
+    unw_nodata: float | None = None,
+    ccl_nodata: float | None = 65535,
     init_method: str = "mst",
     cost: str = "smooth",
     scratchdir: Filename | None = None,
@@ -58,9 +59,11 @@ def unwrap_snaphu_py(
         Set wrapped phase/correlation to 0 where mask is 0 before unwrapping.
         If not mask is provided, this is ignored.
         By default True.
-    nodata : float | str, optional.
+    unw_nodata : float , optional.
         If providing `unwrap_callback`, provide the nodata value for your
         unwrapping function.
+    ccl_nodata : float, optional
+        Nodata value for the connected component labels.
     init_method : str, choices = {"mcf", "mst"}
         initialization method, by default "mst"
     cost : str
@@ -98,10 +101,10 @@ def unwrap_snaphu_py(
     try:
         with (
             snaphu.io.Raster.create(
-                unw_filename, like=igram, nodata=nodata, dtype="f4"
+                unw_filename, like=igram, nodata=unw_nodata, dtype="f4"
             ) as unw,
             snaphu.io.Raster.create(
-                cc_filename, like=igram, nodata=nodata, dtype="u4"
+                cc_filename, like=igram, nodata=ccl_nodata, dtype="u2"
             ) as conncomp,
         ):
             # Unwrap and store the results in the `unw` and `conncomp` rasters.

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -21,7 +21,7 @@ def unwrap_snaphu_py(
     tile_overlap: tuple[int, int] = (0, 0),
     nproc: int = 1,
     mask_file: Filename | None = None,
-    zero_where_masked: bool = True,
+    zero_where_masked: bool = False,
     nodata: str | float | None = None,
     init_method: str = "mst",
     cost: str = "smooth",

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -6,7 +6,7 @@ from dolphin._log import get_log
 from dolphin._types import Filename
 from dolphin.utils import full_suffix
 
-from ._constants import CONNCOMP_SUFFIX
+from ._constants import CONNCOMP_SUFFIX, DEFAULT_CCL_NODATA, DEFAULT_UNW_NODATA
 from ._utils import _zero_from_mask
 
 logger = get_log(__name__)
@@ -22,8 +22,8 @@ def unwrap_snaphu_py(
     nproc: int = 1,
     mask_file: Filename | None = None,
     zero_where_masked: bool = False,
-    unw_nodata: float | None = None,
-    ccl_nodata: float | None = 65535,
+    unw_nodata: float | None = DEFAULT_CCL_NODATA,
+    ccl_nodata: int | None = DEFAULT_UNW_NODATA,
     init_method: str = "mst",
     cost: str = "smooth",
     scratchdir: Filename | None = None,

--- a/src/dolphin/unwrap/_tophu.py
+++ b/src/dolphin/unwrap/_tophu.py
@@ -10,7 +10,7 @@ from dolphin._types import Filename
 from dolphin.utils import full_suffix
 from dolphin.workflows import UnwrapMethod
 
-from ._constants import CONNCOMP_SUFFIX
+from ._constants import CONNCOMP_SUFFIX, DEFAULT_CCL_NODATA, DEFAULT_UNW_NODATA
 from ._utils import _redirect_unwrapping_log, _zero_from_mask
 
 logger = get_log(__name__)
@@ -27,7 +27,8 @@ def multiscale_unwrap(
     zero_where_masked: bool = False,
     unwrap_method: UnwrapMethod = UnwrapMethod.SNAPHU,
     unwrap_callback=None,  # type is `tophu.UnwrapCallback`
-    nodata: str | float | None = None,
+    unw_nodata: float | None = DEFAULT_UNW_NODATA,
+    ccl_nodata: int | None = DEFAULT_CCL_NODATA,
     init_method: str = "mst",
     cost: str = "smooth",
     scratchdir: Filename | None = None,
@@ -63,9 +64,11 @@ def multiscale_unwrap(
     unwrap_callback : tophu.UnwrapCallback
         Alternative to `unwrap_method`: directly provide a callable
         function usable in `tophu`. See [tophu.UnwrapCallback] docs for interface.
-    nodata : float | str, optional.
+    unw_nodata : float, optional.
         If providing `unwrap_callback`, provide the nodata value for your
         unwrapping function.
+    ccl_nodata : float, optional
+        Nodata value for the connected component labels.
     init_method : str, choices = {"mcf", "mst"}
         SNAPHU initialization method, by default "mst"
     cost : str, choices = {"smooth", "defo", "p-norm",}
@@ -95,6 +98,7 @@ def multiscale_unwrap(
         if unwrap_callback is not None:
             # Pass through what the user gave
             return unwrap_callback, nodata
+        # Otherwise, set defaults depending on the method
         unwrap_method = UnwrapMethod(unwrap_method)
         if unwrap_method == UnwrapMethod.ICU:
             unwrap_callback = tophu.ICUUnwrap()
@@ -115,7 +119,9 @@ def multiscale_unwrap(
 
     # Used to track if we can redirect logs or not
     _user_gave_callback = unwrap_callback is not None
-    unwrap_callback, nodata = _get_cb_and_nodata(unwrap_method, unwrap_callback, nodata)
+    unwrap_callback, unw_nodata = _get_cb_and_nodata(
+        unwrap_method, unwrap_callback, unw_nodata
+    )
     # Used to track if we can redirect logs or not
 
     (width, height) = io.get_raster_xysize(ifg_filename)
@@ -136,6 +142,7 @@ def multiscale_unwrap(
         driver="GTiff",
         crs=crs,
         transform=transform,
+        nodata=ccl_nodata,
         **gtiff_options,
     )
     unw_rb = tophu.RasterBand(
@@ -145,7 +152,7 @@ def multiscale_unwrap(
         dtype=np.float32,
         crs=crs,
         transform=transform,
-        nodata=nodata,
+        nodata=unw_nodata,
         **gtiff_options,
     )
 

--- a/src/dolphin/unwrap/_tophu.py
+++ b/src/dolphin/unwrap/_tophu.py
@@ -24,7 +24,7 @@ def multiscale_unwrap(
     ntiles: tuple[int, int],
     nlooks: float,
     mask_file: Filename | None = None,
-    zero_where_masked: bool = True,
+    zero_where_masked: bool = False,
     unwrap_method: UnwrapMethod = UnwrapMethod.SNAPHU,
     unwrap_callback=None,  # type is `tophu.UnwrapCallback`
     nodata: str | float | None = None,

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -293,4 +293,5 @@ def unwrap(
         )
 
     # TODO: post-processing steps go here:
+    # Reset the input nodata values to be nodata in the `unw` and CCL
     return unw_path, conncomp_path

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -165,7 +165,7 @@ def unwrap(
     unw_filename: Filename,
     nlooks: float,
     mask_file: Optional[Filename] = None,
-    zero_where_masked: bool = True,
+    zero_where_masked: bool = False,
     ntiles: Union[int, tuple[int, int]] = 1,
     tile_overlap: tuple[int, int] = (0, 0),
     n_parallel_tiles: int = 1,

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -244,7 +244,7 @@ def unwrap(
         # With no marked `nodata`, just use the passed in mask
         combined_mask_file = mask_file
     else:
-        combined_mask_file = Path(ifg_filename).with_suffix(".masked.tif")
+        combined_mask_file = Path(ifg_filename).with_suffix(".mask.tif")
         create_combined_mask(
             mask_filename=mask_file,
             image_filename=ifg_filename,

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from os import fspath
 from pathlib import Path
 from typing import Optional, Sequence, Union
 
-import numpy as np
 from tqdm.auto import tqdm
 
 from dolphin import io
@@ -15,9 +13,10 @@ from dolphin.utils import DummyProcessPoolExecutor, full_suffix
 from dolphin.workflows import UnwrapMethod
 
 from ._constants import CONNCOMP_SUFFIX, UNW_SUFFIX
+from ._isce3 import unwrap_isce3
 from ._snaphu_py import unwrap_snaphu_py
 from ._tophu import multiscale_unwrap
-from ._utils import _redirect_unwrapping_log, _zero_from_mask, create_combined_mask
+from ._utils import create_combined_mask
 
 logger = get_log(__name__)
 
@@ -253,30 +252,29 @@ def unwrap(
 
     if unwrap_method == UnwrapMethod.SNAPHU:
         # Pass everything to snaphu-py
-        return unwrap_snaphu_py(
+        unw_path, conncomp_path = unwrap_snaphu_py(
             ifg_filename,
             corr_filename,
             unw_filename,
             nlooks,
             ntiles=ntiles,
             tile_overlap=tile_overlap,
-            mask_file=mask_file,
+            mask_file=combined_mask_file,
             nproc=n_parallel_tiles,
             zero_where_masked=zero_where_masked,
             init_method=init_method,
             cost=cost,
             scratchdir=scratchdir,
         )
-
-    if any(t > 1 for t in ntiles):
-        return multiscale_unwrap(
+    elif any(t > 1 for t in ntiles):
+        unw_path, conncomp_path = multiscale_unwrap(
             ifg_filename,
             corr_filename,
             unw_filename,
             downsample_factor,
             ntiles=ntiles,
             nlooks=nlooks,
-            mask_file=mask_file,
+            mask_file=combined_mask_file,
             zero_where_masked=zero_where_masked,
             init_method=init_method,
             cost=cost,
@@ -284,84 +282,15 @@ def unwrap(
             scratchdir=scratchdir,
             log_to_file=log_to_file,
         )
-
-    # Now we're using PHASS or ICU within isce3
-    from isce3.io import Raster
-    from isce3.unwrap import ICU, Phass
-
-    shape = io.get_raster_xysize(ifg_filename)[::-1]
-    corr_shape = io.get_raster_xysize(corr_filename)[::-1]
-    if shape != corr_shape:
-        msg = f"correlation {corr_shape} and interferogram {shape} shapes don't match"
-        raise ValueError(msg)
-
-    ifg_raster = Raster(fspath(ifg_filename))
-    corr_raster = Raster(fspath(corr_filename))
-    UNW_SUFFIX = full_suffix(unw_filename)
-
-    # Get the driver based on the output file extension
-    if Path(unw_filename).suffix == ".tif":
-        driver = "GTiff"
-        opts = list(io.DEFAULT_TIFF_OPTIONS)
     else:
-        driver = "ENVI"
-        opts = list(io.DEFAULT_ENVI_OPTIONS)
-
-    # Create output rasters for unwrapped phase & connected component labels.
-    # Writing with `io.write_arr` because isce3 doesn't have creation options
-    io.write_arr(
-        arr=None,
-        output_name=unw_filename,
-        driver=driver,
-        like_filename=ifg_filename,
-        dtype=np.float32,
-        options=opts,
-    )
-    conncomp_filename = str(unw_filename).replace(UNW_SUFFIX, CONNCOMP_SUFFIX)
-    io.write_arr(
-        arr=None,
-        output_name=conncomp_filename,
-        driver="GTiff",
-        dtype=np.uint32,
-        like_filename=ifg_filename,
-        options=io.DEFAULT_TIFF_OPTIONS,
-    )
-
-    # The different raster classes have different APIs, so we need to
-    # create the raster objects differently.
-    unw_raster = Raster(fspath(unw_filename), True)
-    conncomp_raster = Raster(fspath(conncomp_filename), True)
-
-    _redirect_unwrapping_log(unw_filename, unwrap_method.value)
-
-    if zero_where_masked and mask_file is not None:
-        logger.info(f"Zeroing phase/corr of pixels masked in {mask_file}")
-        zeroed_ifg_file, zeroed_corr_file = _zero_from_mask(
-            ifg_filename, corr_filename, mask_file
+        unw_path, conncomp_path = unwrap_isce3(
+            ifg_filename,
+            corr_filename,
+            unw_filename,
+            mask_file=combined_mask_file,
+            unwrap_method=unwrap_method,
+            zero_where_masked=zero_where_masked,
         )
-        corr_raster = Raster(fspath(zeroed_corr_file))
-        ifg_raster = Raster(fspath(zeroed_ifg_file))
 
-    logger.info(
-        f"Unwrapping size {(ifg_raster.length, ifg_raster.width)} {ifg_filename} to"
-        f" {unw_filename} using {unwrap_method.value}"
-    )
-    if unwrap_method == UnwrapMethod.PHASS:
-        # TODO: expose the configuration for phass?
-        # If we ever find cases where changing help, then yes we should
-        # coherence_thresh: float = 0.2
-        # good_coherence: float = 0.7
-        # min_region_size: int = 200
-        unwrapper = Phass()
-    else:
-        unwrapper = ICU(buffer_lines=shape[0])
-
-    unwrapper.unwrap(
-        unw_raster,
-        conncomp_raster,
-        ifg_raster,
-        corr_raster,
-    )
-
-    del unw_raster, conncomp_raster
-    return Path(unw_filename), Path(conncomp_filename)
+    # TODO: post-processing steps go here:
+    return unw_path, conncomp_path

--- a/src/dolphin/unwrap/_utils.py
+++ b/src/dolphin/unwrap/_utils.py
@@ -3,11 +3,71 @@ from __future__ import annotations
 from os import fspath
 from pathlib import Path
 
+import rasterio as rio
+
 from dolphin import io
 from dolphin._log import get_log
 from dolphin._types import Filename
 
 logger = get_log(__name__)
+
+
+def create_combined_mask(
+    mask_filename: Filename,
+    image_filename: Filename,
+    output_filename: Filename | None = None,
+    band: int = 1,
+) -> Path:
+    """Create a combined a nodata mask from `image_filename` with `mask_filename`.
+
+    This function reads the nodata values from `image_filename` and the existing
+    mask from `mask_filename`. It combines these two masks such that a pixel is
+    considered valid only if it is valid in both masks.
+
+    Parameters
+    ----------
+    mask_filename : PathOrStr
+        The file path of the existing mask file. This mask specifies pixels that
+        are valid (1) or invalid (0).
+    image_filename : PathOrStr
+        The file path of the image file. This file's nodata values are used to
+        generate a mask of valid and invalid pixels.
+    output_filename : PathOrStr, optional, default=None
+        The file path where the combined mask will be saved.
+        If None, creates "combined_mask.tif" in the same directory as `mask_filename`
+    band : int, default=1
+        The band of the image from which to read the nodata values.
+
+    Returns
+    -------
+    Path
+        The path to the created combined mask file.
+
+    Raises
+    ------
+    ValueError
+        If `image_filename` does not have any nodata values defined
+
+    """
+    with rio.open(image_filename) as src:
+        if not src.nodatavals:
+            msg = f"{image_filename} does not have any `nodata` values."
+            raise ValueError(msg)
+        # https://rasterio.readthedocs.io/en/stable/topics/masks.html
+        # rasterio loads this where 0 means the pixel is masked, and
+        # 255 is valid.
+        # coerce to True == valid pixels
+        nd_mask = src.read_masks(band).astype(bool)
+
+    # In the existing mask, 1 should be valid, 0 invalid
+    mask = io.load_gdal(mask_filename).astype(bool)
+    # A valid output has to be valid in the mask, AND not be a `nodata`
+    combined = mask & nd_mask
+
+    if output_filename is None:
+        output_filename = Path(mask_filename).parent / "combined_mask.tif"
+    io.write_arr(like_filename=mask_filename, arr=combined, output_name=output_filename)
+    return Path(output_filename)
 
 
 def _zero_from_mask(

--- a/tests/test_unwrap.py
+++ b/tests/test_unwrap.py
@@ -157,7 +157,7 @@ class TestTophu:
             corr_filename=corr_raster,
             unw_filename=unw_filename,
             unwrap_callback=unwrap_callback,
-            nodata=0,
+            unw_nodata=0,
             nlooks=1,
             ntiles=(2, 2),
             downsample_factor=(3, 3),

--- a/tests/test_unwrap_utils.py
+++ b/tests/test_unwrap_utils.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from dolphin import io
+from dolphin.unwrap import _utils
+
+# Dataset has no geotransform, gcps, or rpcs. The identity matrix will be returned.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore::rasterio.errors.NotGeoreferencedWarning",
+    "ignore:.*io.FileIO.*:pytest.PytestUnraisableExceptionWarning",
+)
+
+
+@pytest.fixture()
+def corr_raster(raster_100_by_200):
+    # Make a correlation raster of all 1s in the same directory as the raster
+    d = Path(raster_100_by_200).parent
+    arr = np.ones((100, 200), dtype="float32")
+    # The first 20 rows have nodata
+    arr[:20, :] = np.nan
+    filename = d / "corr_raster.cor.tif"
+    io.write_arr(
+        arr=arr,
+        output_name=filename,
+        like_filename=raster_100_by_200,
+        nodata=np.nan,
+        driver="GTiff",
+    )
+    return filename
+
+
+@pytest.fixture()
+def mask_raster(raster_100_by_200):
+    # Make a correlation raster of all 1s in the same directory as the raster
+    d = Path(raster_100_by_200).parent
+    filename = d / "mask.tif"
+    arr = np.ones((100, 200), dtype=np.uint8)
+    # Mask the first 20 columns
+    arr[:, :20] = 0
+    io.write_arr(
+        arr=arr,
+        output_name=filename,
+        like_filename=raster_100_by_200,
+        driver="GTiff",
+    )
+    return filename
+
+
+def test_create_combined_mask(corr_raster, mask_raster):
+    out_raster = _utils.create_combined_mask(
+        mask_filename=mask_raster, image_filename=corr_raster
+    )
+    assert Path(out_raster).name == "combined_mask.tif"
+    mask = io.load_gdal(out_raster)
+    assert (mask[:20] == 0).all()
+    assert (mask[:, :20] == 0).all()
+    assert (mask[20:, 20:] == 1).all()


### PR DESCRIPTION
- Combine the nodata region with the `mask_file` to pass through to unwrappers
- Update regions which are nodata in interferograms to be nodata in unwrapped phase
- Use `uint16` data type for connected component labels

Before
![image](https://github.com/isce-framework/dolphin/assets/8291800/f38efbb3-23de-40f0-b4ec-63f9d415a3f5)

after
![image](https://github.com/isce-framework/dolphin/assets/8291800/19fd90e0-639e-4550-8451-d94678834c85)
