### PR TITLE
Use compression/tiling by default in snaphu outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
-# [Unreleased](https://github.com/isce-framework/dolphin/compare/v0.13.0...main)
+# [Unreleased](https://github.com/isce-framework/dolphin/compare/v0.14.1...main)
 
-# [0.14.1](https://github.com/isce-framework/dolphin/compare/v0.13.0...main) - 2024-02-15
+**Changed**
+
+- Combine the nodata region with the `mask_file` to pass through to unwrappers
+- Update regions which are nodata in interferograms to be nodata in unwrapped phase
+- Use `uint16` data type for connected component labels
+
+# [0.14.1](https://github.com/isce-framework/dolphin/compare/v0.14.0...0.14.1) - 2024-02-15
 
 **Fixed**
 
@@ -8,7 +14,7 @@
 - Fixed `linalg.norm`` to be pixelwise in `process_coherence_matrices` in #234
 
 
-# [0.14.0](https://github.com/isce-framework/dolphin/compare/v0.13.0...main) - 2024-02-13
+# [0.14.0](https://github.com/isce-framework/dolphin/compare/v0.13.0...0.14.0) - 2024-02-13
 
 **Fixed**
 - Temporal coherence and eigenvalue rasters were switched in their naming

--- a/src/dolphin/io/_core.py
+++ b/src/dolphin/io/_core.py
@@ -46,24 +46,30 @@ __all__ = [
     "DEFAULT_DATETIME_FORMAT",
     "DEFAULT_HDF5_OPTIONS",
     "DEFAULT_TIFF_OPTIONS",
-    "DEFAULT_TILE_SIZE",
+    "DEFAULT_TILE_SHAPE",
 ]
 
 
 DEFAULT_DATETIME_FORMAT = "%Y%m%d"
-DEFAULT_TILE_SIZE = [128, 128]
-DEFAULT_TIFF_OPTIONS = (
-    "COMPRESS=DEFLATE",
-    "ZLEVEL=4",
-    "BIGTIFF=YES",
-    "TILED=YES",
-    f"BLOCKXSIZE={DEFAULT_TILE_SIZE[1]}",
-    f"BLOCKYSIZE={DEFAULT_TILE_SIZE[0]}",
+DEFAULT_TILE_SHAPE = [128, 128]
+# For use in rasterio
+DEFAULT_TIFF_OPTIONS_RIO = {
+    "compress": "deflate",
+    "zlevel": 4,
+    "bigtiff": "yes",
+    "tiled": "yes",
+    "blockxsize": DEFAULT_TILE_SHAPE[1],
+    "blockysize": DEFAULT_TILE_SHAPE[0],
+}
+# For gdal's bindings
+DEFAULT_TIFF_OPTIONS = tuple(
+    f"{k.upper()}={v}" for k, v in DEFAULT_TIFF_OPTIONS_RIO.items()
 )
+
 DEFAULT_ENVI_OPTIONS = ("SUFFIX=ADD",)
 DEFAULT_HDF5_OPTIONS = {
     # https://docs.h5py.org/en/stable/high/dataset.html#filter-pipeline
-    "chunks": DEFAULT_TILE_SIZE,
+    "chunks": DEFAULT_TILE_SHAPE,
     "compression": "gzip",
     "compression_opts": 4,
     "shuffle": True,

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from dolphin._log import get_log
 from dolphin._types import Filename
+from dolphin.io._core import DEFAULT_TIFF_OPTIONS_RIO
 from dolphin.utils import full_suffix
 
 from ._constants import CONNCOMP_SUFFIX, DEFAULT_CCL_NODATA, DEFAULT_UNW_NODATA
@@ -101,10 +102,18 @@ def unwrap_snaphu_py(
     try:
         with (
             snaphu.io.Raster.create(
-                unw_filename, like=igram, nodata=unw_nodata, dtype="f4"
+                unw_filename,
+                like=igram,
+                nodata=unw_nodata,
+                dtype="f4",
+                **DEFAULT_TIFF_OPTIONS_RIO,
             ) as unw,
             snaphu.io.Raster.create(
-                cc_filename, like=igram, nodata=ccl_nodata, dtype="u2"
+                cc_filename,
+                like=igram,
+                nodata=ccl_nodata,
+                dtype="u2",
+                **DEFAULT_TIFF_OPTIONS_RIO,
             ) as conncomp,
         ):
             # Unwrap and store the results in the `unw` and `conncomp` rasters.

--- a/src/dolphin/unwrap/_tophu.py
+++ b/src/dolphin/unwrap/_tophu.py
@@ -7,6 +7,7 @@ import numpy as np
 from dolphin import io
 from dolphin._log import get_log
 from dolphin._types import Filename
+from dolphin.io._core import DEFAULT_TIFF_OPTIONS_RIO
 from dolphin.utils import full_suffix
 from dolphin.workflows import UnwrapMethod
 
@@ -132,7 +133,6 @@ def multiscale_unwrap(
 
     # SUFFIX=ADD
     # Convert to something rasterio understands
-    gtiff_options = dict(opt.lower().split("=") for opt in io.DEFAULT_TIFF_OPTIONS)
     logger.debug(f"Saving conncomps to {conncomp_filename}")
     conncomp_rb = tophu.RasterBand(
         conncomp_filename,
@@ -143,7 +143,7 @@ def multiscale_unwrap(
         crs=crs,
         transform=transform,
         nodata=ccl_nodata,
-        **gtiff_options,
+        **DEFAULT_TIFF_OPTIONS_RIO,
     )
     unw_rb = tophu.RasterBand(
         unw_filename,
@@ -153,7 +153,7 @@ def multiscale_unwrap(
         crs=crs,
         transform=transform,
         nodata=unw_nodata,
-        **gtiff_options,
+        **DEFAULT_TIFF_OPTIONS_RIO,
     )
 
     if zero_where_masked and mask_file is not None:

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -322,6 +322,12 @@ def create_ifgs(
         )
         raise NotImplementedError(msg)
 
+    # Dedupe, in case different options made the same ifg
+    requested_ifgs = set(ifg_file_list)
+    # remove ones we aren't using (in the case of a single index)
+    written_ifgs = set(ifg_dir.glob("*.int*"))
+    for p in written_ifgs - requested_ifgs:
+        p.unlink()
     return ifg_file_list
 
 


### PR DESCRIPTION
Currently it's make big, uncompressed tif files. Pass through the rasterio-version of the default GTiff options