### PR TITLE
Set intersection of nodata in SLC stack to `nan` in `run_phase_linking`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# [Unreleased](https://github.com/isce-framework/dolphin/compare/v0.14.1...main)
+# [Unreleased](https://github.com/isce-framework/dolphin/compare/v0.15.0...main)
+
+# [0.15.0](https://github.com/isce-framework/dolphin/compare/v0.14.1...0.15.0) - 2024-02-16
 
 **Changed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Update regions which are nodata in interferograms to be nodata in unwrapped phase
 - Use `uint16` data type for connected component labels
 
+**Fixed**
+
+- Intersection of nodata regions for SLC stack are now all set to `nan` during phase linking
+
 # [0.14.1](https://github.com/isce-framework/dolphin/compare/v0.14.0...0.14.1) - 2024-02-15
 
 **Fixed**

--- a/src/dolphin/phase_link/_core.py
+++ b/src/dolphin/phase_link/_core.py
@@ -190,8 +190,8 @@ def run_phase_linking(
     # We zero out nodata if all pixels within the window had nodata
     mask_looked = take_looks(nodata_mask, *strides, func_type="all")
 
-    # Set no data pixels to np.nan
-    temp_coh = np.where(mask_looked, np.nan, cpl_out.temp_coh)
+    # Convert from jax array back to np
+    temp_coh = np.array(cpl_out.temp_coh)
 
     # Fill in the PS pixels from the original SLC stack, if it was given
     if np.any(ps_mask):
@@ -204,6 +204,10 @@ def run_phase_linking(
             avg_mag,
             reference_idx,
         )
+
+    # Finally, ensure the nodata regions are 0
+    cpx_phase[:, mask_looked] = np.nan
+    temp_coh[mask_looked] = np.nan
 
     return PhaseLinkOutput(
         cpx_phase,

--- a/tests/test_phase_link_core.py
+++ b/tests/test_phase_link_core.py
@@ -26,26 +26,14 @@ def slc_samples(C_truth):
     return simulate.simulate_neighborhood_stack(C, ns)
 
 
-# CPU versions of the MLE and EVD estimates
-@pytest.fixture(scope="module")
-def C_hat(slc_samples):
-    return np.array(covariance.coh_mat_single(slc_samples))
-
-
-# Make the single-pixel comparisons with simple implementation
-@pytest.fixture(scope="module")
-def est_mle_verify(C_hat):
-    return np.angle(simulate.mle(C_hat))
-
-
-@pytest.fixture(scope="module")
-def est_evd_verify(C_hat):
-    return np.angle(simulate.evd(C_hat))
-
-
 @pytest.mark.parametrize("use_evd", [False, True])
-def test_estimation(C_truth, slc_samples, est_mle_verify, est_evd_verify, use_evd):
+def test_estimation(C_truth, slc_samples, use_evd):
     _, truth = C_truth
+
+    C_hat = np.array(covariance.coh_mat_single(slc_samples))
+    # Make the single-pixel comparisons with simple implementation
+    est_mle_verify = np.angle(simulate.mle(C_hat))
+    est_evd_verify = np.angle(simulate.evd(C_hat))
 
     # Check that the estimates are close to the truth
     err_deg = 10
@@ -74,7 +62,7 @@ def test_estimation(C_truth, slc_samples, est_mle_verify, est_evd_verify, use_ev
 
 
 def test_masked(slc_samples, C_truth):
-    slc_stack = slc_samples.reshape(NUM_ACQ, 11, 11)
+    slc_stack = slc_samples.copy().reshape(NUM_ACQ, 11, 11)
     mask = np.zeros((11, 11), dtype=bool)
     # Mask the top row
     mask[0, :] = True
@@ -100,7 +88,7 @@ def test_masked(slc_samples, C_truth):
 
 
 def test_run_phase_linking(slc_samples):
-    slc_stack = slc_samples.reshape(NUM_ACQ, 11, 11)
+    slc_stack = slc_samples.copy().reshape(NUM_ACQ, 11, 11)
     pl_out = _core.run_phase_linking(
         slc_stack,
         half_window=HalfWindow(5, 5),
@@ -116,7 +104,7 @@ def test_run_phase_linking(slc_samples):
 
 
 def test_run_phase_linking_use_slc_amp(slc_samples):
-    slc_stack = slc_samples.reshape(NUM_ACQ, 11, 11)
+    slc_stack = slc_samples.copy().reshape(NUM_ACQ, 11, 11)
     ps_mask = np.zeros((11, 11), dtype=bool)
     # Specify at least 1 ps
     ps_mask[1, 1] = True
@@ -131,7 +119,7 @@ def test_run_phase_linking_use_slc_amp(slc_samples):
 
 
 def test_run_phase_linking_with_shift(slc_samples):
-    slc_stack = slc_samples.reshape(NUM_ACQ, 11, 11)
+    slc_stack = slc_samples.copy().reshape(NUM_ACQ, 11, 11)
     # Pretend there's a shift which should lead to nodata at the intersection
     # First row of the first image
     slc_stack[0, 0, :] = np.nan
@@ -168,7 +156,7 @@ def test_strides_window_sizes(strides, half_window, shape):
 @pytest.mark.parametrize("strides", [1, 2, 3, 4])
 def test_ps_fill(slc_samples, strides):
     rows, cols = 11, 11
-    slc_stack = slc_samples.reshape(NUM_ACQ, rows, cols)
+    slc_stack = slc_samples.copy().reshape(NUM_ACQ, 11, 11)
 
     mle_est = np.zeros((NUM_ACQ, rows // strides, cols // strides), dtype=np.complex64)
     temp_coh = np.zeros(mle_est.shape[1:])
@@ -199,7 +187,7 @@ def test_ps_fill(slc_samples, strides):
 
 @pytest.mark.parametrize("strides", [1, 2, 3])
 def test_run_phase_linking_ps_fill(slc_samples, strides):
-    slc_stack = slc_samples.reshape(NUM_ACQ, 11, 11)
+    slc_stack = slc_samples.copy().reshape(NUM_ACQ, 11, 11)
     ps_idx = 2
     ps_mask = np.zeros((11, 11), dtype=bool)
     ps_mask[ps_idx, ps_idx] = True


### PR DESCRIPTION
This should fix #84

Left is current problem from shifting SLC bursts leading to bad edges, right is correctly keeping only the intersection of the good data footprints.
<img width="1131" alt="image" src="https://github.com/isce-framework/dolphin/assets/8291800/cd4d021f-c3a8-4c60-a307-ef1bf9f7e1b8">
