### PR TITLE
Fix phass unwrap

### DIFF
--- a/.github/workflows/test-build-push.yml
+++ b/.github/workflows/test-build-push.yml
@@ -41,7 +41,7 @@ jobs:
               - conda-forge
       - name: Install
         run: |
-          pip install --no-deps "snaphu>=0.2" "opera-utils>=0.3.0" git+https://github.com/isce-framework/tophu@main
+          pip install "snaphu>=0.2" "opera-utils>=0.3.0" git+https://github.com/isce-framework/tophu@main
           pip install --no-deps .
       - name: Install test dependencies
         run: |

--- a/.github/workflows/test-build-push.yml
+++ b/.github/workflows/test-build-push.yml
@@ -19,6 +19,7 @@ jobs:
           - label: Latest
             spec: >-
               isce3
+              tophu
 
       fail-fast: true
     name: ${{ matrix.os }} • ${{ matrix.deps.label }}
@@ -41,7 +42,7 @@ jobs:
               - conda-forge
       - name: Install
         run: |
-          pip install "snaphu>=0.2" "opera-utils>=0.3.0" git+https://github.com/isce-framework/tophu@main
+          pip install --no-deps "snaphu>=0.2" "opera-utils>=0.3.0" git+https://github.com/isce-framework/tophu@main
           pip install --no-deps .
       - name: Install test dependencies
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ COPY --chown=$MAMBA_USER:$MAMBA_USER . .
 # https://github.com/mamba-org/micromamba-docker#running-commands-in-dockerfile-within-the-conda-environment
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 # For now, manually install tophu/snaphu from git/pip
-RUN python -m pip install "snaphu>=0.2" git+https://github.com/isce-framework/tophu@66df96fc4645f6977421336ed96c553833216c07
+RUN python -m pip install --no-deps "snaphu>=0.2" git+https://github.com/isce-framework/tophu@66df96fc4645f6977421336ed96c553833216c07
 
 # --no-deps because they are installed with conda
 RUN python -m pip install --no-deps .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ COPY --chown=$MAMBA_USER:$MAMBA_USER . .
 # https://github.com/mamba-org/micromamba-docker#running-commands-in-dockerfile-within-the-conda-environment
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 # For now, manually install tophu/snaphu from git/pip
-RUN python -m pip install --no-deps "snaphu>=0.2" git+https://github.com/isce-framework/tophu@66df96fc4645f6977421336ed96c553833216c07
+RUN python -m pip install "snaphu>=0.2" git+https://github.com/isce-framework/tophu@66df96fc4645f6977421336ed96c553833216c07
 
 # --no-deps because they are installed with conda
 RUN python -m pip install --no-deps .

--- a/src/dolphin/unwrap/_isce3.py
+++ b/src/dolphin/unwrap/_isce3.py
@@ -81,17 +81,7 @@ def unwrap_isce3(
         driver = "ENVI"
         opts = list(io.DEFAULT_ENVI_OPTIONS)
 
-    if unwrap_method == UnwrapMethod.PHASS:
-        # TODO: expose the configuration for phass?
-        # If we ever find cases where changing help, then yes we should
-        # coherence_thresh: float = 0.2
-        # good_coherence: float = 0.7
-        # min_region_size: int = 200
-        unwrapper = Phass()
-        unw_nodata = -10_000
-    else:
-        unwrapper = ICU(buffer_lines=shape[0])
-        unw_nodata = 0
+    unw_nodata = -10_000 if unwrap_method == UnwrapMethod.PHASS else 0
     # Create output rasters for unwrapped phase & connected component labels.
     # Writing with `io.write_arr` because isce3 doesn't have creation options
     io.write_arr(
@@ -133,13 +123,28 @@ def unwrap_isce3(
         f"Unwrapping size {(ifg_raster.length, ifg_raster.width)} {ifg_filename} to"
         f" {unw_filename} using {unwrap_method.value}"
     )
+    if unwrap_method == UnwrapMethod.PHASS:
+        # TODO: expose the configuration for phass?
+        # If we ever find cases where changing help, then yes we should
+        # coherence_thresh: float = 0.2
+        # good_coherence: float = 0.7
+        # min_region_size: int = 200
+        unwrapper = Phass()
+        unwrapper.unwrap(
+            ifg_raster,
+            corr_raster,
+            unw_raster,
+            conncomp_raster,
+        )
+    else:
+        unwrapper = ICU(buffer_lines=shape[0])
 
-    unwrapper.unwrap(
-        unw_raster,
-        conncomp_raster,
-        ifg_raster,
-        corr_raster,
-    )
+        unwrapper.unwrap(
+            unw_raster,
+            conncomp_raster,
+            ifg_raster,
+            corr_raster,
+        )
 
     del unw_raster, conncomp_raster
     return Path(unw_filename), Path(conncomp_filename)

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -18,7 +18,6 @@ from ._constants import (
     DEFAULT_UNW_NODATA,
     UNW_SUFFIX,
 )
-from ._isce3 import unwrap_isce3
 from ._snaphu_py import unwrap_snaphu_py
 from ._tophu import multiscale_unwrap
 from ._utils import create_combined_mask, set_nodata_values
@@ -289,7 +288,7 @@ def unwrap(
             cost=cost,
             scratchdir=scratchdir,
         )
-    elif any(t > 1 for t in ntiles):
+    else:
         unw_path, conncomp_path = multiscale_unwrap(
             ifg_filename,
             corr_filename,
@@ -304,15 +303,6 @@ def unwrap(
             unwrap_method=unwrap_method,
             scratchdir=scratchdir,
             log_to_file=log_to_file,
-        )
-    else:
-        unw_path, conncomp_path = unwrap_isce3(
-            ifg_filename,
-            corr_filename,
-            unw_filename,
-            mask_file=combined_mask_file,
-            unwrap_method=unwrap_method,
-            zero_where_masked=zero_where_masked,
         )
 
     # TODO: post-processing steps go here:

--- a/src/dolphin/workflows/unwrapping.py
+++ b/src/dolphin/workflows/unwrapping.py
@@ -93,7 +93,6 @@ def run(
         logger.info("Creating overviews for unwrapped images")
         create_overviews(unwrapped_paths, image_type=ImageType.UNWRAPPED)
         create_overviews(conncomp_paths, image_type=ImageType.CONNCOMP)
-        create_overviews(unwrapped_paths, image_type=ImageType.CORRELATION)
 
     return (unwrapped_paths, conncomp_paths)
 


### PR DESCRIPTION
The order was switched for the input/output rasters when not using Tophu.
Now jump straight to using tophu.