### PR TITLE
Enforce consistency between jax and jaxlib

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -8,7 +8,6 @@ dependencies:
   - gdal>=3.3
   - h5py>=3.6
   - hdf5!=1.12.2 # https://github.com/SciTools/iris/issues/5187 and https://github.com/pydata/xarray/issues/7549
-  - jax>=0.4.19
   - numba>=0.56
   - numpy>=1.23
   - opera-utils>=0.1.5
@@ -20,3 +19,6 @@ dependencies:
   - threadpoolctl>=3.0
   - tqdm>=4.60
   - typing_extensions>=3.10
+  - pip:
+      - jax>=0.4.19
+      - jaxlib>=0.4.19


### PR DESCRIPTION
Consistency between jax and jaxlib can be enforced by installing the most recent versions via pip, which is currently not possible through conda where the two packages are out of sync.

This is necessary as dolphin would crash early on in processing if the two packages are not in sync.