### PR TITLE
Remove `-tap` option from `gdal_merge.py` call

### DIFF
--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -241,8 +241,6 @@ def merge_images(
     if out_dtype is not None:
         out_gdal_dtype = gdal.GetDataTypeName(utils.numpy_to_gdal_type(out_dtype))
         args.extend(["-ot", out_gdal_dtype])
-    if target_aligned_pixels:
-        args.append("-tap")
     if create_only:
         args.append("-create")
     if options is not None:
@@ -253,7 +251,7 @@ def merge_images(
     logger.info(f"Running {' '.join(arg_list)}")
     subprocess.check_call(arg_list)
 
-    # Now clip to
+    # Now clip to the provided bounding box
     gdal.Translate(
         destName=fspath(outfile),
         srcDS=fspath(merge_output),


### PR DESCRIPTION
Adding `-tap` was creating occasional duplicated rows based on something in the `gdal_merge.py` blocking scheme.

The result of `np.diff(merged, axis=0) == 1` looked like this for 2 bursts:
<img width="496" alt="image" src="https://github.com/isce-framework/dolphin/assets/8291800/bfc1067b-3d44-4238-9a89-740dea8fabc0">
(Note that this is not related to any burst-jump artifacts. the line is constant in `y`)

Removing the `-tap` gets rid of this
<img width="496" alt="image" src="https://github.com/isce-framework/dolphin/assets/8291800/8e0cf903-b59c-4e3d-ba1e-a1108b9b4b50">

