### PR TITLE
Toggle zero mask and apply to unw phase field

### DIFF
--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -241,6 +241,8 @@ def merge_images(
     if out_dtype is not None:
         out_gdal_dtype = gdal.GetDataTypeName(utils.numpy_to_gdal_type(out_dtype))
         args.extend(["-ot", out_gdal_dtype])
+    if target_aligned_pixels:
+        args.append("-tap")
     if create_only:
         args.append("-create")
     if options is not None:
@@ -251,7 +253,7 @@ def merge_images(
     logger.info(f"Running {' '.join(arg_list)}")
     subprocess.check_call(arg_list)
 
-    # Now clip to the provided bounding box
+    # Now clip to
     gdal.Translate(
         destName=fspath(outfile),
         srcDS=fspath(merge_output),

--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -1,4 +1,5 @@
 """stitching.py: utilities for combining interferograms into larger images."""
+
 from __future__ import annotations
 
 import math

--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -241,8 +241,6 @@ def merge_images(
     if out_dtype is not None:
         out_gdal_dtype = gdal.GetDataTypeName(utils.numpy_to_gdal_type(out_dtype))
         args.extend(["-ot", out_gdal_dtype])
-    if target_aligned_pixels:
-        args.append("-tap")
     if create_only:
         args.append("-create")
     if options is not None:
@@ -253,7 +251,7 @@ def merge_images(
     logger.info(f"Running {' '.join(arg_list)}")
     subprocess.check_call(arg_list)
 
-    # Now clip to
+    # Now clip to the provided bounding box
     gdal.Translate(
         destName=fspath(outfile),
         srcDS=fspath(merge_output),

--- a/src/dolphin/unwrap/_constants.py
+++ b/src/dolphin/unwrap/_constants.py
@@ -1,7 +1,9 @@
 from typing import Final
 
 CONNCOMP_SUFFIX = ".unw.conncomp.tif"
+CONNCOMP_SUFFIX_ZEROED = ".unw.conncomp.zeroed.cor.tif"
 UNW_SUFFIX = ".unw.tif"
+UNW_SUFFIX_ZEROED = ".unw.zeroed.tif"
 
 UINT16_MAX: Final = 65535
 

--- a/src/dolphin/unwrap/_isce3.py
+++ b/src/dolphin/unwrap/_isce3.py
@@ -147,9 +147,7 @@ def unwrap_isce3(
         )
     if zero_where_masked and mask_file is not None:
         logger.info(f"Zeroing unw/conncomp of pixels masked in {mask_file}")
-        unw_filename, conncomp_filename = _zero_from_mask(
-            unw_filename, conncomp_filename, mask_file
-        )
+        return _zero_from_mask(unw_filename, conncomp_filename, mask_file)
 
     del unw_raster, conncomp_raster
     return Path(unw_filename), Path(conncomp_filename)

--- a/src/dolphin/unwrap/_isce3.py
+++ b/src/dolphin/unwrap/_isce3.py
@@ -145,6 +145,11 @@ def unwrap_isce3(
             ifg_raster,
             corr_raster,
         )
+    if zero_where_masked and mask_file is not None:
+        logger.info(f"Zeroing unw/conncomp of pixels masked in {mask_file}")
+        unw_filename, conncomp_filename = _zero_from_mask(
+            unw_filename, conncomp_filename, mask_file
+        )
 
     del unw_raster, conncomp_raster
     return Path(unw_filename), Path(conncomp_filename)

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -146,8 +146,7 @@ def unwrap_snaphu_py(
             mask.close()
 
     if zero_where_masked and mask_file is not None:
-        logger.info("Zeroing unw/conncomp of pixels masked in "
-                        f"{mask_file}")
+        logger.info("Zeroing unw/conncomp of pixels masked in " f"{mask_file}")
 
         return _zero_from_mask(unw_filename, cc_filename, mask_file)
 

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -144,8 +144,10 @@ def unwrap_snaphu_py(
         corr.close()
         if mask is not None:
             mask.close()
+
     if zero_where_masked and mask_file is not None:
-        logger.info("Zeroing unw/conncomp of pixels masked in " f"{mask_file}")
+        logger.info("Zeroing unw/conncomp of pixels masked in "
+                        f"{mask_file}")
 
         return _zero_from_mask(unw_filename, cc_filename, mask_file)
 

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -145,8 +145,7 @@ def unwrap_snaphu_py(
         if mask is not None:
             mask.close()
         if zero_where_masked and mask_file is not None:
-            logger.info("Zeroing unw/conncomp of pixels masked in "
-                        f"{mask_file}")
+            logger.info("Zeroing unw/conncomp of pixels masked in " f"{mask_file}")
             unw_filename, cc_filename = _zero_from_mask(
                 unw_filename, cc_filename, mask_file
             )

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -144,5 +144,11 @@ def unwrap_snaphu_py(
         corr.close()
         if mask is not None:
             mask.close()
+        if zero_where_masked and mask_file is not None:
+            logger.info("Zeroing unw/conncomp of pixels masked in "
+                        f"{mask_file}")
+            unw_filename, cc_filename = _zero_from_mask(
+                unw_filename, cc_filename, mask_file
+            )
 
     return Path(unw_filename), Path(cc_filename)

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -145,8 +145,7 @@ def unwrap_snaphu_py(
         if mask is not None:
             mask.close()
     if zero_where_masked and mask_file is not None:
-        logger.info("Zeroing unw/conncomp of pixels masked in "
-                        f"{mask_file}")
+        logger.info("Zeroing unw/conncomp of pixels masked in " f"{mask_file}")
 
         return _zero_from_mask(unw_filename, cc_filename, mask_file)
 

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -145,9 +145,9 @@ def unwrap_snaphu_py(
         if mask is not None:
             mask.close()
         if zero_where_masked and mask_file is not None:
-            logger.info("Zeroing unw/conncomp of pixels masked in " f"{mask_file}")
-            unw_filename, cc_filename = _zero_from_mask(
-                str(unw_filename), str(cc_filename), mask_file
-            )
+            logger.info("Zeroing unw/conncomp of pixels masked in "
+                        f"{mask_file}")
+
+            return _zero_from_mask(unw_filename, cc_filename, mask_file)
 
     return Path(unw_filename), Path(cc_filename)

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -147,7 +147,7 @@ def unwrap_snaphu_py(
         if zero_where_masked and mask_file is not None:
             logger.info("Zeroing unw/conncomp of pixels masked in " f"{mask_file}")
             unw_filename, cc_filename = _zero_from_mask(
-                unw_filename, cc_filename, mask_file
+                str(unw_filename), str(cc_filename), mask_file
             )
 
     return Path(unw_filename), Path(cc_filename)

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -144,9 +144,10 @@ def unwrap_snaphu_py(
         corr.close()
         if mask is not None:
             mask.close()
-        if zero_where_masked and mask_file is not None:
-            logger.info("Zeroing unw/conncomp of pixels masked in " f"{mask_file}")
+    if zero_where_masked and mask_file is not None:
+        logger.info("Zeroing unw/conncomp of pixels masked in "
+                        f"{mask_file}")
 
-            return _zero_from_mask(unw_filename, cc_filename, mask_file)
+        return _zero_from_mask(unw_filename, cc_filename, mask_file)
 
     return Path(unw_filename), Path(cc_filename)

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -145,8 +145,7 @@ def unwrap_snaphu_py(
         if mask is not None:
             mask.close()
         if zero_where_masked and mask_file is not None:
-            logger.info("Zeroing unw/conncomp of pixels masked in "
-                        f"{mask_file}")
+            logger.info("Zeroing unw/conncomp of pixels masked in " f"{mask_file}")
 
             return _zero_from_mask(unw_filename, cc_filename, mask_file)
 

--- a/src/dolphin/unwrap/_tophu.py
+++ b/src/dolphin/unwrap/_tophu.py
@@ -185,7 +185,7 @@ def multiscale_unwrap(
     if zero_where_masked and mask_file is not None:
         logger.info(f"Zeroing unw/conncomp of pixels masked in {mask_file}")
         unw_filename, conncomp_filename = _zero_from_mask(
-            unw_filename, conncomp_filename, mask_file
+            str(unw_filename), str(conncomp_filename), mask_file
         )
 
     return Path(unw_filename), Path(conncomp_filename)

--- a/src/dolphin/unwrap/_tophu.py
+++ b/src/dolphin/unwrap/_tophu.py
@@ -182,5 +182,10 @@ def multiscale_unwrap(
         ntiles=ntiles,
         scratchdir=scratchdir,
     )
+    if zero_where_masked and mask_file is not None:
+        logger.info(f"Zeroing unw/conncomp of pixels masked in {mask_file}")
+        unw_filename, conncomp_filename = _zero_from_mask(
+            unw_filename, conncomp_filename, mask_file
+        )
 
     return Path(unw_filename), Path(conncomp_filename)

--- a/src/dolphin/unwrap/_tophu.py
+++ b/src/dolphin/unwrap/_tophu.py
@@ -184,8 +184,6 @@ def multiscale_unwrap(
     )
     if zero_where_masked and mask_file is not None:
         logger.info(f"Zeroing unw/conncomp of pixels masked in {mask_file}")
-        unw_filename, conncomp_filename = _zero_from_mask(
-            str(unw_filename), str(conncomp_filename), mask_file
-        )
+        return _zero_from_mask(unw_filename, conncomp_filename, mask_file)
 
     return Path(unw_filename), Path(conncomp_filename)

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -184,26 +184,17 @@ def run(
 
     if zero_where_masked and mask_file is not None:
         all_out_files = [
-            Path(
-                str(outf).replace(
-                    UNW_SUFFIX, 
-                    UNW_SUFFIX_ZEROED
-                )
-            )
+            Path(str(outf).replace(UNW_SUFFIX, UNW_SUFFIX_ZEROED))
             for outf in all_out_files
         ]
         conncomp_files = [
-            Path(
-                str(outf).replace(
-                    UNW_SUFFIX_ZEROED, 
-                    CONNCOMP_SUFFIX_ZEROED
-                )
-            )
-        for outf in all_out_files
+            Path(str(outf).replace(UNW_SUFFIX_ZEROED, CONNCOMP_SUFFIX_ZEROED))
+            for outf in all_out_files
         ]
     else:
         conncomp_files = [
-            Path(str(outf).replace(UNW_SUFFIX, CONNCOMP_SUFFIX)) for outf in all_out_files
+            Path(str(outf).replace(UNW_SUFFIX, CONNCOMP_SUFFIX))
+            for outf in all_out_files
         ]
     return all_out_files, conncomp_files
 
@@ -395,7 +386,6 @@ def unwrap(
     set_nodata_values(
         filename=conncomp_path, output_nodata=ccl_nodata, like_filename=ifg_filename
     )
-
 
     # Transfer ambiguity numbers from filtered unwrapped interferogram
     # back to original interferogram

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -4,9 +4,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Optional, Sequence, Union
 
+import numpy as np
 from tqdm.auto import tqdm
 
-from dolphin import io
+from dolphin import goldstein, io
 from dolphin._log import get_log, log_runtime
 from dolphin._types import Filename
 from dolphin.utils import DummyProcessPoolExecutor, full_suffix
@@ -184,17 +185,26 @@ def run(
 
     if zero_where_masked and mask_file is not None:
         all_out_files = [
-            Path(str(outf).replace(UNW_SUFFIX, UNW_SUFFIX_ZEROED))
+            Path(
+                str(outf).replace(
+                    UNW_SUFFIX, 
+                    UNW_SUFFIX_ZEROED
+                )
+            )
             for outf in all_out_files
         ]
         conncomp_files = [
-            Path(str(outf).replace(UNW_SUFFIX_ZEROED, CONNCOMP_SUFFIX_ZEROED))
-            for outf in all_out_files
+            Path(
+                str(outf).replace(
+                    UNW_SUFFIX_ZEROED, 
+                    CONNCOMP_SUFFIX_ZEROED
+                )
+            )
+        for outf in all_out_files
         ]
     else:
         conncomp_files = [
-            Path(str(outf).replace(UNW_SUFFIX, CONNCOMP_SUFFIX))
-            for outf in all_out_files
+            Path(str(outf).replace(UNW_SUFFIX, CONNCOMP_SUFFIX)) for outf in all_out_files
         ]
     return all_out_files, conncomp_files
 
@@ -386,6 +396,7 @@ def unwrap(
     set_nodata_values(
         filename=conncomp_path, output_nodata=ccl_nodata, like_filename=ifg_filename
     )
+
 
     # Transfer ambiguity numbers from filtered unwrapped interferogram
     # back to original interferogram

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -184,17 +184,26 @@ def run(
 
     if zero_where_masked and mask_file is not None:
         all_out_files = [
-            Path(str(outf).replace(UNW_SUFFIX, UNW_SUFFIX_ZEROED))
+            Path(
+                str(outf).replace(
+                    UNW_SUFFIX, 
+                    UNW_SUFFIX_ZEROED
+                )
+            )
             for outf in all_out_files
         ]
         conncomp_files = [
-            Path(str(outf).replace(UNW_SUFFIX_ZEROED, CONNCOMP_SUFFIX_ZEROED))
-            for outf in all_out_files
+            Path(
+                str(outf).replace(
+                    UNW_SUFFIX_ZEROED, 
+                    CONNCOMP_SUFFIX_ZEROED
+                )
+            )
+        for outf in all_out_files
         ]
     else:
         conncomp_files = [
-            Path(str(outf).replace(UNW_SUFFIX, CONNCOMP_SUFFIX))
-            for outf in all_out_files
+            Path(str(outf).replace(UNW_SUFFIX, CONNCOMP_SUFFIX)) for outf in all_out_files
         ]
     return all_out_files, conncomp_files
 
@@ -332,16 +341,18 @@ def unwrap(
             driver=driver,
             options=opts,
         )
+        unwrapper_ifg_filename = filt_ifg_filename
+        unwrapper_unw_filename = scratch_unw_filename
     else:
-        Path(ifg_filename)
-        Path(unw_filename)
+        unwrapper_ifg_filename = Path(ifg_filename)
+        unwrapper_unw_filename = Path(unw_filename)
 
     if unwrap_method == UnwrapMethod.SNAPHU:
         # Pass everything to snaphu-py
         unw_path, conncomp_path = unwrap_snaphu_py(
-            ifg_filename,
+            unwrapper_ifg_filename,
             corr_filename,
-            unw_filename,
+            unwrapper_unw_filename,
             nlooks,
             ntiles=ntiles,
             tile_overlap=tile_overlap,
@@ -356,9 +367,9 @@ def unwrap(
         )
     else:
         unw_path, conncomp_path = multiscale_unwrap(
-            ifg_filename,
+            unwrapper_ifg_filename,
             corr_filename,
-            unw_filename,
+            unwrapper_unw_filename,
             downsample_factor,
             ntiles=ntiles,
             nlooks=nlooks,
@@ -384,6 +395,7 @@ def unwrap(
     set_nodata_values(
         filename=conncomp_path, output_nodata=ccl_nodata, like_filename=ifg_filename
     )
+
 
     # Transfer ambiguity numbers from filtered unwrapped interferogram
     # back to original interferogram

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -185,26 +185,17 @@ def run(
 
     if zero_where_masked and mask_file is not None:
         all_out_files = [
-            Path(
-                str(outf).replace(
-                    UNW_SUFFIX, 
-                    UNW_SUFFIX_ZEROED
-                )
-            )
+            Path(str(outf).replace(UNW_SUFFIX, UNW_SUFFIX_ZEROED))
             for outf in all_out_files
         ]
         conncomp_files = [
-            Path(
-                str(outf).replace(
-                    UNW_SUFFIX_ZEROED, 
-                    CONNCOMP_SUFFIX_ZEROED
-                )
-            )
-        for outf in all_out_files
+            Path(str(outf).replace(UNW_SUFFIX_ZEROED, CONNCOMP_SUFFIX_ZEROED))
+            for outf in all_out_files
         ]
     else:
         conncomp_files = [
-            Path(str(outf).replace(UNW_SUFFIX, CONNCOMP_SUFFIX)) for outf in all_out_files
+            Path(str(outf).replace(UNW_SUFFIX, CONNCOMP_SUFFIX))
+            for outf in all_out_files
         ]
     return all_out_files, conncomp_files
 
@@ -396,7 +387,6 @@ def unwrap(
     set_nodata_values(
         filename=conncomp_path, output_nodata=ccl_nodata, like_filename=ifg_filename
     )
-
 
     # Transfer ambiguity numbers from filtered unwrapped interferogram
     # back to original interferogram

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -176,26 +176,17 @@ def run(
 
     if zero_where_masked and mask_file is not None:
         all_out_files = [
-            Path(
-                str(outf).replace(
-                    UNW_SUFFIX, 
-                    UNW_SUFFIX_ZEROED
-                )
-            )
+            Path(str(outf).replace(UNW_SUFFIX, UNW_SUFFIX_ZEROED))
             for outf in all_out_files
         ]
         conncomp_files = [
-            Path(
-                str(outf).replace(
-                    UNW_SUFFIX_ZEROED, 
-                    CONNCOMP_SUFFIX_ZEROED
-                )
-            )
-        for outf in all_out_files
+            Path(str(outf).replace(UNW_SUFFIX_ZEROED, CONNCOMP_SUFFIX_ZEROED))
+            for outf in all_out_files
         ]
     else:
         conncomp_files = [
-            Path(str(outf).replace(UNW_SUFFIX, CONNCOMP_SUFFIX)) for outf in all_out_files
+            Path(str(outf).replace(UNW_SUFFIX, CONNCOMP_SUFFIX))
+            for outf in all_out_files
         ]
     return all_out_files, conncomp_files
 

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -35,6 +35,7 @@ def run(
     *,
     nlooks: float = 5,
     mask_file: Optional[Filename] = None,
+    zero_where_masked: bool = False,
     unwrap_method: UnwrapMethod = UnwrapMethod.SNAPHU,
     init_method: str = "mst",
     cost: str = "smooth",
@@ -63,6 +64,10 @@ def run(
     mask_file : Filename, optional
         Path to binary byte mask file, by default None.
         Assumes that 1s are valid pixels and 0s are invalid.
+    zero_where_masked : bool, optional
+        Set wrapped phase/correlation to 0 where mask is 0 before unwrapping.
+        If not mask is provided, this is ignored.
+        By default True.
     unwrap_method : UnwrapMethod or str, optional, default = "snaphu"
         Choice of unwrapping algorithm to use.
         Choices: {"snaphu", "icu", "phass"}
@@ -152,6 +157,7 @@ def run(
                 cost=cost,
                 unwrap_method=unwrap_method,
                 mask_file=mask_file,
+                zero_where_masked=zero_where_masked,
                 downsample_factor=downsample_factor,
                 ntiles=ntiles,
                 tile_overlap=tile_overlap,

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -184,26 +184,17 @@ def run(
 
     if zero_where_masked and mask_file is not None:
         all_out_files = [
-            Path(
-                str(outf).replace(
-                    UNW_SUFFIX, 
-                    UNW_SUFFIX_ZEROED
-                )
-            )
+            Path(str(outf).replace(UNW_SUFFIX, UNW_SUFFIX_ZEROED))
             for outf in all_out_files
         ]
         conncomp_files = [
-            Path(
-                str(outf).replace(
-                    UNW_SUFFIX_ZEROED, 
-                    CONNCOMP_SUFFIX_ZEROED
-                )
-            )
-        for outf in all_out_files
+            Path(str(outf).replace(UNW_SUFFIX_ZEROED, CONNCOMP_SUFFIX_ZEROED))
+            for outf in all_out_files
         ]
     else:
         conncomp_files = [
-            Path(str(outf).replace(UNW_SUFFIX, CONNCOMP_SUFFIX)) for outf in all_out_files
+            Path(str(outf).replace(UNW_SUFFIX, CONNCOMP_SUFFIX))
+            for outf in all_out_files
         ]
     return all_out_files, conncomp_files
 
@@ -341,11 +332,9 @@ def unwrap(
             driver=driver,
             options=opts,
         )
-        unwrapper_ifg_filename = filt_ifg_filename
-        unwrapper_unw_filename = scratch_unw_filename
     else:
-        unwrapper_ifg_filename = Path(ifg_filename)
-        unwrapper_unw_filename = Path(unw_filename)
+        Path(ifg_filename)
+        Path(unw_filename)
 
     if unwrap_method == UnwrapMethod.SNAPHU:
         # Pass everything to snaphu-py
@@ -395,7 +384,6 @@ def unwrap(
     set_nodata_values(
         filename=conncomp_path, output_nodata=ccl_nodata, like_filename=ifg_filename
     )
-
 
     # Transfer ambiguity numbers from filtered unwrapped interferogram
     # back to original interferogram

--- a/src/dolphin/workflows/_cli_config.py
+++ b/src/dolphin/workflows/_cli_config.py
@@ -24,6 +24,7 @@ def create_config(
     keep_paths_relative: bool = False,
     work_directory: Optional[Path] = Path(),
     mask_file: Optional[str] = None,
+    zero_where_masked: bool = False,
     ministack_size: Optional[int] = 15,
     half_window_size: tuple[int, int] = (11, 5),
     shp_method: ShpMethod = ShpMethod.GLRT,
@@ -102,6 +103,7 @@ def create_config(
             "downsample_factor": downsample_factor,
             "n_parallel_jobs": n_parallel_unwrap,
             "run_unwrap": not no_unwrap,
+            "zero_where_masked": zero_where_masked,
         },
         timeseries_options={
             "run_inversion": not no_inversion,

--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -204,6 +204,13 @@ class UnwrapOptions(BaseModel, extra="forbid"):
         "smooth",
         description="Statistical cost mode method for SNAPHU.",
     )
+    zero_where_masked: bool = Field(
+        False,
+        description=(
+            "Set wrapped phase/correlation to 0 where mask is 0 before unwrapping. "
+            " a single-reference network is used."
+        ),
+    )
 
     @field_validator("ntiles", "downsample_factor", mode="before")
     @classmethod

--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -214,7 +214,6 @@ class UnwrapOptions(BaseModel, extra="forbid"):
         False,
         description=(
             "Set wrapped phase/correlation to 0 where mask is 0 before unwrapping. "
-            " a single-reference network is used."
         ),
     )
 

--- a/src/dolphin/workflows/unwrapping.py
+++ b/src/dolphin/workflows/unwrapping.py
@@ -78,6 +78,7 @@ def run(
         output_path=output_path,
         nlooks=nlooks,
         mask_file=output_mask,
+        zero_where_masked=unwrap_options.zero_where_masked,
         max_jobs=unwrap_options.n_parallel_jobs,
         ntiles=unwrap_options.ntiles,
         tile_overlap=unwrap_options.tile_overlap,


### PR DESCRIPTION
When [passing a mask](https://github.com/sssangha/dolphin/blob/0a67fa1ee77e70f0171aa96a8ea1d949453f775a/src/dolphin/unwrap/_unwrap.py#L37) for unwrapping, it seems to be ignored even though an INT mask was clearly generated (see screenshot below):
![Screenshot 2024-03-12 at 3 10 16 PM](https://github.com/isce-framework/dolphin/assets/13227405/f56ecf6d-f6d9-4d0f-8461-06a80a86672d)

After digging a bit, I realized that this was because by default the [zero_where_masked](https://github.com/sssangha/dolphin/blob/0a67fa1ee77e70f0171aa96a8ea1d949453f775a/src/dolphin/unwrap/_unwrap.py#L38) parameter is set to False, which according to this conditional [downstream](https://github.com/sssangha/dolphin/blob/0a67fa1ee77e70f0171aa96a8ea1d949453f775a/src/dolphin/unwrap/_snaphu_py.py#L90) must be set to true in addition to providing a mask.

In this PR, I've exposed this `zero_where_masked` parameter so it can be toggled. It seems to work now as here is the resulting UNW phase field:
![Screenshot 2024-03-12 at 10 39 41 AM](https://github.com/isce-framework/dolphin/assets/13227405/f5543ee8-f1b4-45df-ab7e-4827993045bb)

That said, clearly snaphu-related artifacts appear to persist in the masked region, so I made some additions to the code to apply the mask to the final unw phase field which now looks as I would expect:
![Screenshot 2024-03-12 at 11 02 06 AM](https://github.com/isce-framework/dolphin/assets/13227405/ee9b6d6c-cdf0-4cec-9c9c-68b0ec788005)
