### PR TITLE
fix bug for get dates

### DIFF
--- a/src/dolphin/atmosphere/ionosphere.py
+++ b/src/dolphin/atmosphere/ionosphere.py
@@ -117,11 +117,11 @@ def estimate_ionospheric_delay(
             )
             continue
 
-        reference_date = (ref_date,)
-        secondary_date = (sec_date,)
+        reference_date = next(key for key in slc_files if ref_date in key)
+        secondary_date = next(key for key in slc_files if sec_date in key)
 
         secondary_time = oput.get_zero_doppler_time(slc_files[secondary_date][0])
-        if len(slc_files[reference_date]) == 0:
+        if "compressed" in str(slc_files[reference_date][0]).lower():
             # this is for when we have compressed slcs but the actual
             # reference date does not exist in the input data
             reference_time = secondary_time
@@ -130,14 +130,14 @@ def estimate_ionospheric_delay(
 
         reference_vtec = read_zenith_tec(
             time=reference_time,
-            tec_file=tec_files[reference_date][0],
+            tec_file=tec_files[(ref_date,)][0],
             lat=latc,
             lon=lonc,
         )
 
         secondary_vtec = read_zenith_tec(
             time=secondary_time,
-            tec_file=tec_files[secondary_date][0],
+            tec_file=tec_files[(sec_date,)][0],
             lat=latc,
             lon=lonc,
         )

--- a/src/dolphin/atmosphere/ionosphere.py
+++ b/src/dolphin/atmosphere/ionosphere.py
@@ -117,6 +117,16 @@ def estimate_ionospheric_delay(
             )
             continue
 
+        # The keys in slc_files do not necessarily have one date,
+        # it means with the production file naming convention,
+        # there will be multiple dates stored in the keys from get_dates
+        # function. So in the following if we set reference_date = (ref_date, ),
+        # there will be an error that it does not find the key.
+        # Examples of the file naming convention for CSLC and compressed cslc is:
+        # OPERA_L2_CSLC-S1_T042-088905-IW1\
+        #                       _20221119T000000Z_20221120T000000Z_S1A_VV_v1.0.h5
+        # OPERA_L2_COMPRESSED-CSLC-S1_T042-088905-IW1_20221107T000000Z_\
+        #           20221107T000000Z_20230506T000000Z_20230507T000000Z_VV_v1.0.h5
         reference_date = next(key for key in slc_files if ref_date in key)
         secondary_date = next(key for key in slc_files if sec_date in key)
 

--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -282,7 +282,7 @@ class CompressedSlcInfo(BaseModel):
     ) -> CompressedSlcInfo:
         """Parse just the dates from a compressed SLC filename."""
         try:
-            ref, start, end = get_dates(filename, fmt=date_fmt)
+            ref, start, end = get_dates(filename, fmt=date_fmt)[0:3]
         except IndexError as e:
             msg = f"{filename} does not have 3 dates like {date_fmt}"
             raise ValueError(msg) from e


### PR DESCRIPTION
The get_dates function returns all the dates in the file name but the code was expecting only 3. Since the naming convention in the production data has 4, the output of this function had to be modified.