### PR TITLE
temporary fix for compressed SLC metadata

### DIFF
--- a/src/dolphin/atmosphere/ionosphere.py
+++ b/src/dolphin/atmosphere/ionosphere.py
@@ -128,7 +128,14 @@ def estimate_ionospheric_delay(
         # OPERA_L2_COMPRESSED-CSLC-S1_T042-088905-IW1_20221107T000000Z_\
         #           20221107T000000Z_20230506T000000Z_20230507T000000Z_VV_v1.0.h5
         reference_date = next(key for key in slc_files if ref_date in key)
-        secondary_date = next(key for key in slc_files if sec_date in key)
+        # temporary fix for compressed SLCs while the required metadata i not included
+        # in them. there will be modification in a future PR to add metadata to
+        # compressed SLCs
+        secondary_date = next(
+            key
+            for key in slc_files
+            if sec_date in key and "compressed" not in str(slc_files[key][0]).lower()
+        )
 
         secondary_time = oput.get_zero_doppler_time(slc_files[secondary_date][0])
         if "compressed" in str(slc_files[reference_date][0]).lower():

--- a/src/dolphin/atmosphere/troposphere.py
+++ b/src/dolphin/atmosphere/troposphere.py
@@ -167,7 +167,14 @@ def estimate_tropospheric_delay(
             continue
 
         reference_date = next(key for key in slc_files if ref_date in key)
-        secondary_date = next(key for key in slc_files if sec_date in key)
+        # temporary fix for compressed SLCs while the required metadata i not included
+        # in them. there will be modification in a future PR to add metadata to
+        # compressed SLCs
+        secondary_date = next(
+            key
+            for key in slc_files
+            if sec_date in key and "compressed" not in str(slc_files[key][0]).lower()
+        )
 
         if (ref_date,) not in troposphere_files or (sec_date,) not in troposphere_files:
             logger.warning(f"Weather-model files do not exist for {date_str}, skipping")


### PR DESCRIPTION
required metadata is not currently included in compressed SLCs, we need to add it in a separate PR
this is a temporary fix  