### PR TITLE
Enforce convention for conncomp files to be consistent with unw files

### DIFF
--- a/src/dolphin/unwrap/_constants.py
+++ b/src/dolphin/unwrap/_constants.py
@@ -1,7 +1,7 @@
 from typing import Final
 
 CONNCOMP_SUFFIX = ".unw.conncomp.tif"
-CONNCOMP_SUFFIX_ZEROED = ".unw.conncomp.zeroed.cor.tif"
+CONNCOMP_SUFFIX_ZEROED = ".unw.conncomp.zeroed.tif"
 UNW_SUFFIX = ".unw.tif"
 UNW_SUFFIX_ZEROED = ".unw.zeroed.tif"
 

--- a/src/dolphin/unwrap/_utils.py
+++ b/src/dolphin/unwrap/_utils.py
@@ -131,7 +131,7 @@ def _zero_from_mask(
     ifg_filename: Filename, corr_filename: Filename, mask_filename: Filename
 ) -> tuple[Path, Path]:
     zeroed_ifg_file = Path(ifg_filename).with_suffix(".zeroed.tif")
-    zeroed_corr_file = Path(corr_filename).with_suffix(".zeroed.cor.tif")
+    zeroed_corr_file = Path(corr_filename).with_suffix(".zeroed.tif")
 
     if io.get_raster_xysize(ifg_filename) != io.get_raster_xysize(mask_filename):
         msg = f"Mask {mask_filename} and {ifg_filename} shapes don't match"


### PR DESCRIPTION
Currently, masked conncomp files would have a filename with the `*.unw.conncomp.zeroed.cor.tif` suffix.

I've proposed changes which would enforce a filename suffix of `*.unw.conncomp.zeroed.tif` instead.