### PR TITLE
Add ability to run displacement workflow with CSLCs on S3

### DIFF
--- a/src/dolphin/io/_paths.py
+++ b/src/dolphin/io/_paths.py
@@ -67,12 +67,13 @@ class S3Path(GeneralPath):
             self.path: Path = s3_url.path
             self._trailing_slash: str = s3_url._trailing_slash
         else:
-            parsed: ParseResult = urlparse(s3_url)
+            s = str(s3_url).strip()
+            parsed: ParseResult = urlparse(str(s))
             self._scheme = parsed.scheme
             self._netloc = self.bucket = parsed.netloc
             self._parsed = parsed
             self.path = Path(parsed.path)
-            self._trailing_slash = "/" if s3_url.endswith("/") else ""
+            self._trailing_slash = "/" if s.endswith("/") else ""
 
         if self._scheme != "s3":
             raise ValueError(f"{s3_url} is not an S3 url")
@@ -119,7 +120,7 @@ class S3Path(GeneralPath):
     def suffix(self):
         return self.path.suffix
 
-    def resolve(self) -> S3Path:
+    def resolve(self, strict: bool = False) -> S3Path:
         """Resolve the path to an absolute path- S3 paths are always absolute."""
         return self
 

--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -17,7 +17,7 @@ from pydantic import (
 from dolphin import __version__ as _dolphin_version
 from dolphin._log import get_log
 from dolphin._types import Bbox
-from dolphin.io import DEFAULT_HDF5_OPTIONS, DEFAULT_TIFF_OPTIONS
+from dolphin.io import DEFAULT_HDF5_OPTIONS, DEFAULT_TIFF_OPTIONS, S3Path
 
 from ._enums import ShpMethod, UnwrapMethod
 from ._yaml_model import YamlModel
@@ -518,4 +518,10 @@ def _read_file_list_or_glob(cls, value):  # noqa: ARG001:
             msg = f"Input file list {v_path} does not exist or is not a file."
             raise ValueError(msg)
 
-    return list(value)
+    out = []
+    for v in list(value):
+        try:
+            out.append(S3Path(v))
+        except ValueError:
+            out.append(Path(v))
+    return out

--- a/src/dolphin/workflows/config/_displacement.py
+++ b/src/dolphin/workflows/config/_displacement.py
@@ -8,13 +8,16 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    PlainSerializer,
     StringConstraints,
+    WithJsonSchema,
     field_validator,
     model_validator,
 )
 
 from dolphin._log import get_log
-from dolphin._types import TropoModel, TropoType
+from dolphin._types import GeneralPath, TropoModel, TropoType
+from dolphin.io import S3Path
 
 from ._common import (
     InputOptions,
@@ -98,15 +101,14 @@ class CorrectionOptions(BaseModel, extra="forbid"):
         return v if v is not None else []
 
 
-from pydantic import (
-    PlainSerializer,
-)
-from typing_extensions import Annotated
-
-from dolphin.io import S3Path
-
 CslcFileList = Annotated[
-    list[S3Path | Path], PlainSerializer(lambda x: [str(f) for f in x])
+    # Any Path-like object is acceptable
+    list[GeneralPath],
+    # All Paths will be serialized to strings:
+    PlainSerializer(lambda x: [str(f) for f in x]),
+    # Let Pydantic know what the JSON Schema should be for this custom protocol:
+    # https://docs.pydantic.dev/latest/concepts/json_schema/#withjsonschema-annotation
+    WithJsonSchema({"type": "array", "items": {"type": "string", "format": "uri"}}),
 ]
 
 


### PR DESCRIPTION
Currently working to configure S3 urls, but stuck on a GDAL limitation: You can't (reliably) combine `/vsis3` with the netcdf driver and a subdataset. 

Wwe can read from one stack of HDF5 files with `HDF5:...`, but there will be no georeferencing information, meaning we can't combine multiple OPERA stacks.

Even if that gets working, there's probably still a few bugs to iron out with `s3://...` strings and subdatasets. But since it's a pretty sizeable blocker, I'm marking this as draft for now.