### PR TITLE
Add functions for compression options and repacking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,12 +49,13 @@ pre-commit install
 
 This will set up the linters and formatters to run on any staged files before you commit them.
 
-It is recommended to install [`ruff]`(https://docs.astral.sh/ruff/) into your editor so that the linting/formatting problems will be evident to you before you try to commit.
+It is recommended to install [`ruff`](https://docs.astral.sh/ruff/) into your editor so that the linting/formatting problems will be evident to you before you try to commit.
 
 ## Running tests
 
 After making functional changes, you can rerun the existing tests using [`pytest`](https://docs.pytest.org).
 The extra packages required for testing can be installed:
+
 ```bash
 # Run "pip install -e" to install with extra development requirements
 python -m pip install -e ".[test]"

--- a/src/dolphin/interferogram.py
+++ b/src/dolphin/interferogram.py
@@ -653,6 +653,7 @@ def estimate_interferometric_correlations(
     window_size: tuple[int, int],
     out_driver: str = "GTiff",
     out_suffix: str = ".cor.tif",
+    options: Sequence[str] = io.DEFAULT_TIFF_OPTIONS,
 ) -> list[Path]:
     """Estimate correlations for a sequence of interferograms.
 
@@ -668,6 +669,8 @@ def estimate_interferometric_correlations(
         Name of output GDAL driver, by default "GTiff"
     out_suffix : str, optional
         File suffix to use for correlation files, by default ".cor.tif"
+    options : list[str], optional
+        GDAL Creation options for the output array
 
     Returns
     -------
@@ -692,6 +695,7 @@ def estimate_interferometric_correlations(
             output_name=cor_path,
             like_filename=ifg_path,
             driver=out_driver,
+            options=options,
         )
     return corr_paths
 

--- a/src/dolphin/io/__init__.py
+++ b/src/dolphin/io/__init__.py
@@ -4,4 +4,5 @@ from ._core import *
 from ._paths import *
 from ._process import *
 from ._readers import *
+from ._utils import *
 from ._writers import *

--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -259,6 +259,7 @@ def merge_images(
         projWin=proj_win,
         resampleAlg=resample_alg,
         format=driver,
+        creationOptions=options,
     )
 
     temp_dir.cleanup()

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -338,7 +338,7 @@ def run(
         stitched_amp_dispersion_file=stitched_amp_dispersion_file,
         stitched_shp_count_file=stitched_shp_count_file,
         unwrapped_paths=unwrapped_paths,
-        # TODO: Let's keep the uwrapped_paths since all the outputs are
+        # TODO: Let's keep the unwrapped_paths since all the outputs are
         # corresponding to those and if we have a network unwrapping, the
         # inversion would create different single-reference network and we need
         # to update other products like conncomp


### PR DESCRIPTION
- Fixed the options missing from the `stitching` call, which was leading to uncompressed stitched outputs
- Made a helper function to setup different GDAL compression settings
- Made `repack_rasters` to call `gdal.Translate` on multiple images to recreate with new compression settings.
  - For instance, we'll want to call with `lerc_deflate` to compress correlation files to a max precision of something like 0.001 - 0.005