### PR TITLE
correct the unwrapped file output path

### DIFF
--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -439,4 +439,4 @@ def unwrap(
         assert scratchdir is not None
         shutil.rmtree(scratchdir)
 
-    return unw_path, conncomp_path
+    return Path(unw_filename), conncomp_path


### PR DESCRIPTION
The output path to unwrapped file was set to the interpolated/filtered file instead of the one with ambiguities added
This is used in orca