### PR TITLE
Redo logging to use `dictConfig`, always log to a `.jsonl` file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include src/dolphin/shp/glrt_cutoffs.csv
-include src/dolphin/shp/kld_cutoffs.csv
 include src/dolphin/py.typed
+include src/dolphin/log-config.json

--- a/src/dolphin/_decorators.py
+++ b/src/dolphin/_decorators.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import functools
+import logging
 import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Callable
 
-from dolphin._log import get_log
-
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "atomic_output",

--- a/src/dolphin/_log.py
+++ b/src/dolphin/_log.py
@@ -51,6 +51,10 @@ def setup_logging(debug: bool = False, filename: PathOrStr | None = None):
         config["loggers"]["dolphin"]["handlers"].append("file")
         config["handlers"]["file"]["filename"] = filename
 
+    if "filename" not in config["handlers"]["file"]:
+        # We never passed in a filename: don't log to a file
+        config["handlers"].pop("file")
+
     logging.config.dictConfig(config)
     # Temp work around for tqdm on py312
     if sys.version_info.major == 3 and sys.version_info.minor == 12:

--- a/src/dolphin/atmosphere/ionosphere.py
+++ b/src/dolphin/atmosphere/ionosphere.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 import re
 from pathlib import Path
 from typing import Mapping, Sequence
@@ -14,11 +15,10 @@ from rasterio.warp import transform_bounds
 from scipy import interpolate
 
 from dolphin import io
-from dolphin._log import get_log
 from dolphin._types import Bbox, Filename
 from dolphin.utils import format_date_pair
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 ###########
 

--- a/src/dolphin/atmosphere/troposphere.py
+++ b/src/dolphin/atmosphere/troposphere.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 from dataclasses import dataclass
 from os import fspath
 from pathlib import Path
@@ -15,11 +16,10 @@ from rasterio.warp import transform_bounds
 from scipy.interpolate import RegularGridInterpolator
 
 from dolphin import io
-from dolphin._log import get_log
 from dolphin._types import Bbox, Filename, TropoModel, TropoType
 from dolphin.utils import format_date_pair
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 ###########
 

--- a/src/dolphin/interferogram.py
+++ b/src/dolphin/interferogram.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import itertools
+import logging
 from dataclasses import dataclass
 from os import fspath
 from pathlib import Path
@@ -17,12 +18,11 @@ from scipy.ndimage import uniform_filter
 from tqdm.contrib.concurrent import thread_map
 
 from dolphin import io, utils
-from dolphin._log import get_log
 from dolphin._types import DateOrDatetime, Filename, T
 
 gdal.UseExceptions()
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 DEFAULT_SUFFIX = ".int.vrt"
 
@@ -687,8 +687,6 @@ def estimate_interferometric_correlations(
         Paths to newly written correlation files.
 
     """
-    logger = get_log()
-
     corr_paths: list[Path] = []
     for ifg_path in ifg_paths:
         cor_path = Path(ifg_path).with_suffix(out_suffix)

--- a/src/dolphin/interpolation.py
+++ b/src/dolphin/interpolation.py
@@ -1,12 +1,12 @@
+import logging
+
 import numba
 import numpy as np
 from numpy.typing import ArrayLike
 
-from dolphin._log import get_log
-
 from .similarity import get_circle_idxs
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 def interpolate(

--- a/src/dolphin/io/_background.py
+++ b/src/dolphin/io/_background.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import abc
+import logging
 from queue import Empty, Full, Queue
 from threading import Event, Thread, main_thread
 
-from dolphin._log import get_log
-
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 0.5
 

--- a/src/dolphin/io/_core.py
+++ b/src/dolphin/io/_core.py
@@ -6,6 +6,7 @@ wrapper functions to write/iterate over blocks of large raster files.
 
 from __future__ import annotations
 
+import logging
 import math
 from dataclasses import dataclass
 from os import fspath
@@ -18,12 +19,11 @@ from numpy.typing import ArrayLike, DTypeLike
 from osgeo import gdal
 from pyproj import CRS
 
-from dolphin._log import get_log
 from dolphin._types import Bbox, Filename, Strides
 from dolphin.utils import compute_out_shape, gdal_to_numpy_type, numpy_to_gdal_type
 
 gdal.UseExceptions()
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "load_gdal",

--- a/src/dolphin/log-config.json
+++ b/src/dolphin/log-config.json
@@ -13,7 +13,6 @@
                 "message": "message",
                 "timestamp": "timestamp",
                 "logger": "name",
-                "module": "module",
                 "function": "funcName",
                 "line": "lineno",
                 "thread_name": "threadName"
@@ -23,31 +22,23 @@
     "handlers": {
         "stderr": {
             "class": "logging.StreamHandler",
-            "level": "WARNING",
+            "level": "INFO",
             "formatter": "simple",
             "stream": "ext://sys.stderr"
         },
-        "file_json": {
+        "file": {
             "class": "logging.handlers.RotatingFileHandler",
             "level": "INFO",
             "formatter": "json",
             "maxBytes": 10000000,
             "backupCount": 3
-        },
-        "queue_handler": {
-            "class": "logging.handlers.QueueHandler",
-            "handlers": [
-                "stderr",
-                "file_json"
-            ],
-            "respect_handler_level": true
         }
     },
     "loggers": {
         "dolphin": {
             "level": "INFO",
             "handlers": [
-                "queue_handler"
+                "stderr"
             ]
         }
     }

--- a/src/dolphin/log-config.json
+++ b/src/dolphin/log-config.json
@@ -1,0 +1,54 @@
+{
+    "version": 1,
+    "disable_existing_loggers": false,
+    "formatters": {
+        "simple": {
+            "format": "[%(levelname)s|%(module)s|L%(lineno)d] %(asctime)s: %(message)s",
+            "datefmt": "%Y-%m-%dT%H:%M:%S%z"
+        },
+        "json": {
+            "()": "dolphin._log.JSONFormatter",
+            "fmt_keys": {
+                "level": "levelname",
+                "message": "message",
+                "timestamp": "timestamp",
+                "logger": "name",
+                "module": "module",
+                "function": "funcName",
+                "line": "lineno",
+                "thread_name": "threadName"
+            }
+        }
+    },
+    "handlers": {
+        "stderr": {
+            "class": "logging.StreamHandler",
+            "level": "WARNING",
+            "formatter": "simple",
+            "stream": "ext://sys.stderr"
+        },
+        "file_json": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "level": "INFO",
+            "formatter": "json",
+            "maxBytes": 10000000,
+            "backupCount": 3
+        },
+        "queue_handler": {
+            "class": "logging.handlers.QueueHandler",
+            "handlers": [
+                "stderr",
+                "file_json"
+            ],
+            "respect_handler_level": true
+        }
+    },
+    "loggers": {
+        "dolphin": {
+            "level": "INFO",
+            "handlers": [
+                "queue_handler"
+            ]
+        }
+    }
+}

--- a/src/dolphin/masking.py
+++ b/src/dolphin/masking.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from enum import IntEnum
 from os import fspath
 from pathlib import Path
@@ -9,13 +10,12 @@ import numpy as np
 from osgeo import gdal
 
 from dolphin import io
-from dolphin._log import get_log
 from dolphin._types import Filename
 from dolphin.utils import numpy_to_gdal_type
 
 gdal.UseExceptions()
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 class MaskConvention(IntEnum):

--- a/src/dolphin/ps.py
+++ b/src/dolphin/ps.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import shutil
 import warnings
 from pathlib import Path
@@ -12,13 +13,12 @@ from numpy.typing import ArrayLike
 from osgeo import gdal
 
 from dolphin import io, utils
-from dolphin._log import get_log
 from dolphin._types import Filename
 from dolphin.io import EagerLoader, StackReader
 
 gdal.UseExceptions()
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 NODATA_VALUES = {"ps": 255, "amp_dispersion": 0.0, "amp_mean": 0.0}
 

--- a/src/dolphin/shp/__init__.py
+++ b/src/dolphin/shp/__init__.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 import numpy as np
 from numpy.typing import ArrayLike
 
-from dolphin._log import get_log
 from dolphin.workflows import ShpMethod
 
 from . import _glrt, _ks
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 __all__ = ["estimate_neighbors"]
 

--- a/src/dolphin/shp/_ks.py
+++ b/src/dolphin/shp/_ks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from math import exp, sqrt
 from typing import Optional
 
@@ -8,13 +9,12 @@ import numpy as np
 from numba import cuda
 from numpy.typing import ArrayLike
 
-from dolphin._log import get_log
 from dolphin._types import Strides
 from dolphin.utils import _get_slices, compute_out_shape
 
 from ._common import remove_unconnected
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 _get_slices = numba.njit(_get_slices)

--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import math
 import subprocess
 import tempfile
@@ -18,11 +19,10 @@ from rasterio.warp import transform_bounds
 from tqdm.contrib.concurrent import thread_map
 
 from dolphin import io, utils
-from dolphin._log import get_log
 from dolphin._types import Bbox, Filename
 from dolphin.io import DEFAULT_DATETIME_FORMAT
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 def merge_by_date(

--- a/src/dolphin/unwrap/_isce3.py
+++ b/src/dolphin/unwrap/_isce3.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+import logging
 from os import fspath
 from pathlib import Path
 
 import numpy as np
 
 from dolphin import io
-from dolphin._log import get_log
 from dolphin._types import Filename
 from dolphin.utils import full_suffix
 from dolphin.workflows import UnwrapMethod
@@ -14,7 +14,7 @@ from dolphin.workflows import UnwrapMethod
 from ._constants import CONNCOMP_SUFFIX, DEFAULT_CCL_NODATA
 from ._utils import _redirect_unwrapping_log, _zero_from_mask
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 __all__ = ["unwrap_isce3"]
 

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Optional
 
 from numpy.typing import ArrayLike
 
-from dolphin._log import get_log
 from dolphin._types import Filename
 from dolphin.io._core import DEFAULT_TIFF_OPTIONS_RIO
 from dolphin.utils import full_suffix
@@ -13,7 +13,7 @@ from dolphin.utils import full_suffix
 from ._constants import CONNCOMP_SUFFIX, DEFAULT_CCL_NODATA, DEFAULT_UNW_NODATA
 from ._utils import _zero_from_mask
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 def unwrap_snaphu_py(

--- a/src/dolphin/unwrap/_tophu.py
+++ b/src/dolphin/unwrap/_tophu.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import numpy as np
 
 from dolphin import io
-from dolphin._log import get_log
 from dolphin._types import Filename
 from dolphin.io._core import DEFAULT_TIFF_OPTIONS_RIO
 from dolphin.utils import full_suffix
@@ -14,7 +14,7 @@ from dolphin.workflows import UnwrapMethod
 from ._constants import CONNCOMP_SUFFIX, DEFAULT_CCL_NODATA, DEFAULT_UNW_NODATA
 from ._utils import _redirect_unwrapping_log, _zero_from_mask
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 def multiscale_unwrap(

--- a/src/dolphin/unwrap/_utils.py
+++ b/src/dolphin/unwrap/_utils.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
+import logging
 from os import fspath
 from pathlib import Path
 
 import rasterio as rio
 
 from dolphin import io
-from dolphin._log import get_log
 from dolphin._types import Filename
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 def create_combined_mask(

--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 import math
 import resource
 import sys
@@ -16,13 +17,12 @@ import numpy as np
 from numpy.typing import ArrayLike, DTypeLike
 from osgeo import gdal, gdal_array, gdalconst
 
-from dolphin._log import get_log
 from dolphin._types import Bbox, Filename, P, Strides, T
 
 DateOrDatetime = Union[datetime.date, datetime.datetime]
 
 gdal.UseExceptions()
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 def numpy_to_gdal_type(np_dtype: DTypeLike) -> int:

--- a/src/dolphin/workflows/_utils.py
+++ b/src/dolphin/workflows/_utils.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 from pathlib import Path
-
-from dolphin._log import get_log
 
 from .config import DisplacementWorkflow
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 def _create_burst_cfg(

--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -362,7 +362,10 @@ class WorkflowBase(YamlModel):
     worker_settings: WorkerSettings = Field(default_factory=WorkerSettings)
     log_file: Optional[Path] = Field(
         default=None,
-        description="Path to output log file (in addition to logging to `stderr`).",
+        description=(
+            "Path to output log file (in addition to logging to `stderr`)."
+            " Default logs to `dolphin.log` within `work_directory`"
+        ),
     )
     creation_time_utc: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),

--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import glob
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -15,14 +16,13 @@ from pydantic import (
 )
 
 from dolphin import __version__ as _dolphin_version
-from dolphin._log import get_log
 from dolphin._types import Bbox
 from dolphin.io import DEFAULT_HDF5_OPTIONS, DEFAULT_TIFF_OPTIONS
 
 from ._enums import ShpMethod
 from ._yaml_model import YamlModel
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "HalfWindow",
@@ -383,11 +383,10 @@ class WorkflowBase(YamlModel):
             # Save all directories as absolute paths
             self.work_directory = self.work_directory.resolve(strict=False)
 
-    def create_dir_tree(self, debug: bool = False) -> None:
+    def create_dir_tree(self) -> None:
         """Create the directory tree for the workflow."""
-        log = get_log(debug=debug)
         for d in self._directory_list:
-            log.debug(f"Creating directory: {d}")
+            logger.debug(f"Creating directory: {d}")
             d.mkdir(parents=True, exist_ok=True)
 
 

--- a/src/dolphin/workflows/config/_displacement.py
+++ b/src/dolphin/workflows/config/_displacement.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Annotated, Any, Optional
 
@@ -13,7 +14,6 @@ from pydantic import (
     model_validator,
 )
 
-from dolphin._log import get_log
 from dolphin._types import TropoModel, TropoType
 
 from ._common import (
@@ -33,7 +33,7 @@ __all__ = [
     "CorrectionOptions",
 ]
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 # Add a class for troposphere, ionosphere corrections, with geometry files and DEM

--- a/src/dolphin/workflows/config/_ps.py
+++ b/src/dolphin/workflows/config/_ps.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 from pydantic import ConfigDict, Field, field_validator
-
-from dolphin._log import get_log
 
 from ._common import (
     InputOptions,
@@ -19,7 +18,7 @@ __all__ = [
     "PsWorkflow",
 ]
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 class PsWorkflow(WorkflowBase):

--- a/src/dolphin/workflows/config/_unwrap_options.py
+++ b/src/dolphin/workflows/config/_unwrap_options.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Literal
 
@@ -10,11 +11,9 @@ from pydantic import (
     field_validator,
 )
 
-from dolphin._log import get_log
-
 from ._enums import UnwrapMethod
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "UnwrapOptions",

--- a/src/dolphin/workflows/config/_unwrapping.py
+++ b/src/dolphin/workflows/config/_unwrapping.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
+# from dolphin._dates import get_dates, sort_files_by_date
+import logging
 from pathlib import Path
 from typing import Any
 
 from pydantic import ConfigDict, Field, field_validator
-
-# from dolphin._dates import get_dates, sort_files_by_date
-from dolphin._log import get_log
 
 from ._common import (
     InputOptions,
@@ -20,7 +19,7 @@ __all__ = [
     "UnwrappingWorkflow",
 ]
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 class UnwrappingWorkflow(WorkflowBase):

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from __future__ import annotations
 
+import logging
+
 # import contextlib
 import multiprocessing as mp
 from collections import defaultdict
@@ -15,7 +17,7 @@ from opera_utils import group_by_burst, group_by_date  # , get_dates
 from tqdm.auto import tqdm
 
 from dolphin import __version__, io, timeseries, utils
-from dolphin._log import get_log, log_runtime
+from dolphin._log import log_runtime
 from dolphin.atmosphere import estimate_ionospheric_delay, estimate_tropospheric_delay
 from dolphin.workflows import CallFunc
 
@@ -23,7 +25,7 @@ from . import stitching_bursts, unwrapping, wrapped_phase
 from ._utils import _create_burst_cfg, _remove_dir_if_empty
 from .config import DisplacementWorkflow  # , TimeseriesOptions
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 class OutputPaths(NamedTuple):
@@ -60,7 +62,8 @@ def run(
 
     """
     # Set the logging level for all `dolphin.` modules
-    logger = get_log(name="dolphin", debug=debug, filename=cfg.log_file)
+    # logger = get_log(name="dolphin", debug=debug, filename=cfg.log_file)
+    # TODO: need to pass the cfg filename for the logger
     logger.debug(pformat(cfg.model_dump()))
 
     if not cfg.worker_settings.gpu_enabled:

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -17,7 +17,7 @@ from opera_utils import group_by_burst, group_by_date  # , get_dates
 from tqdm.auto import tqdm
 
 from dolphin import __version__, io, timeseries, utils
-from dolphin._log import log_runtime
+from dolphin._log import log_runtime, setup_logging
 from dolphin.atmosphere import estimate_ionospheric_delay, estimate_tropospheric_delay
 from dolphin.workflows import CallFunc
 
@@ -62,7 +62,7 @@ def run(
 
     """
     # Set the logging level for all `dolphin.` modules
-    # logger = get_log(name="dolphin", debug=debug, filename=cfg.log_file)
+    setup_logging(debug=debug, filename=cfg.log_file)
     # TODO: need to pass the cfg filename for the logger
     logger.debug(pformat(cfg.model_dump()))
 

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -10,7 +10,6 @@ from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from os import PathLike
 from pathlib import Path
-from pprint import pformat
 from typing import Mapping, NamedTuple, Sequence
 
 from opera_utils import group_by_burst, group_by_date  # , get_dates
@@ -61,10 +60,12 @@ def run(
         Enable debug logging, by default False.
 
     """
+    if cfg.log_file is None:
+        cfg.log_file = cfg.work_directory / "dolphin.log"
     # Set the logging level for all `dolphin.` modules
     setup_logging(debug=debug, filename=cfg.log_file)
     # TODO: need to pass the cfg filename for the logger
-    logger.debug(pformat(cfg.model_dump()))
+    logger.debug(cfg.model_dump())
 
     if not cfg.worker_settings.gpu_enabled:
         utils.disable_gpu()

--- a/src/dolphin/workflows/ps.py
+++ b/src/dolphin/workflows/ps.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from pprint import pformat
 
@@ -7,11 +8,13 @@ import opera_utils
 
 import dolphin.ps
 from dolphin import __version__
-from dolphin._log import get_log, log_runtime
+from dolphin._log import log_runtime
 from dolphin.io import VRTStack
 from dolphin.utils import get_max_memory_usage
 
 from .config import PsWorkflow
+
+logger = logging.getLogger(__name__)
 
 
 @log_runtime
@@ -34,7 +37,6 @@ def run(
 
     """
     # Set the logging level for all `dolphin.` modules
-    logger = get_log(name="dolphin", debug=debug, filename=cfg.log_file)
     logger.debug(pformat(cfg.model_dump()))
 
     output_file_list = [

--- a/src/dolphin/workflows/ps.py
+++ b/src/dolphin/workflows/ps.py
@@ -8,7 +8,7 @@ import opera_utils
 
 import dolphin.ps
 from dolphin import __version__
-from dolphin._log import log_runtime
+from dolphin._log import log_runtime, setup_logging
 from dolphin.io import VRTStack
 from dolphin.utils import get_max_memory_usage
 
@@ -37,6 +37,7 @@ def run(
 
     """
     # Set the logging level for all `dolphin.` modules
+    setup_logging(debug=debug, filename=cfg.log_file)
     logger.debug(pformat(cfg.model_dump()))
 
     output_file_list = [

--- a/src/dolphin/workflows/sequential.py
+++ b/src/dolphin/workflows/sequential.py
@@ -5,6 +5,7 @@ Initially based on [@Ansari2017SequentialEstimatorEfficient].
 
 from __future__ import annotations
 
+import logging
 from itertools import chain
 from os import fspath
 from pathlib import Path
@@ -13,7 +14,6 @@ from typing import Optional
 from osgeo_utils import gdal_calc
 
 from dolphin import io
-from dolphin._log import get_log
 from dolphin._types import Filename
 from dolphin.io import VRTStack
 from dolphin.stack import MiniStackPlanner
@@ -21,7 +21,7 @@ from dolphin.stack import MiniStackPlanner
 from .config import ShpMethod
 from .single import run_wrapped_phase_single
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 __all__ = ["run_wrapped_phase_sequential"]
 

--- a/src/dolphin/workflows/single.py
+++ b/src/dolphin/workflows/single.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -12,7 +13,6 @@ from tqdm.auto import tqdm
 
 from dolphin import io, shp
 from dolphin._decorators import atomic_output
-from dolphin._log import get_log
 from dolphin._types import Filename, HalfWindow, Strides
 from dolphin.io import EagerLoader, StridedBlockManager, VRTStack
 from dolphin.phase_link import PhaseLinkRuntimeError, compress, run_phase_linking
@@ -20,7 +20,7 @@ from dolphin.stack import MiniStackInfo
 
 from .config import ShpMethod
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 __all__ = ["run_wrapped_phase_single"]
 

--- a/src/dolphin/workflows/stitching_bursts.py
+++ b/src/dolphin/workflows/stitching_bursts.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Sequence
 
 from dolphin import stitching
-from dolphin._log import get_log, log_runtime
+from dolphin._log import log_runtime
 from dolphin._overviews import ImageType, create_image_overviews, create_overviews
 from dolphin._types import Bbox
 from dolphin.interferogram import estimate_interferometric_correlations
@@ -14,7 +15,7 @@ from dolphin.io._utils import _format_for_gdal, get_gtiff_options
 
 from .config import OutputOptions
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 @log_runtime

--- a/src/dolphin/workflows/unwrapping.py
+++ b/src/dolphin/workflows/unwrapping.py
@@ -2,17 +2,18 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Sequence
 
 from dolphin import io, stitching, unwrap
-from dolphin._log import get_log, log_runtime
+from dolphin._log import log_runtime
 from dolphin._overviews import ImageType, create_overviews
 from dolphin._types import PathOrStr
 
 from .config import UnwrapOptions
 
-logger = get_log(__name__)
+logger = logging.getLogger(__name__)
 
 
 @log_runtime

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -9,7 +9,7 @@ import numpy as np
 from opera_utils import get_dates, make_nodata_mask
 
 from dolphin import interferogram, ps, stack
-from dolphin._log import log_runtime
+from dolphin._log import log_runtime, setup_logging
 from dolphin.io import VRTStack
 
 from . import InterferogramNetwork, sequential
@@ -53,6 +53,7 @@ def run(
         Path to the created SHP counts file.
 
     """
+    setup_logging(debug=debug, filename=cfg.log_file)
     if tqdm_kwargs is None:
         tqdm_kwargs = {}
     work_dir = cfg.work_directory

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 from pathlib import Path
 from typing import Optional, Sequence, cast
 
@@ -8,11 +9,13 @@ import numpy as np
 from opera_utils import get_dates, make_nodata_mask
 
 from dolphin import interferogram, ps, stack
-from dolphin._log import get_log, log_runtime
+from dolphin._log import log_runtime
 from dolphin.io import VRTStack
 
 from . import InterferogramNetwork, sequential
 from .config import DisplacementWorkflow
+
+logger = logging.getLogger(__name__)
 
 
 @log_runtime
@@ -52,7 +55,6 @@ def run(
     """
     if tqdm_kwargs is None:
         tqdm_kwargs = {}
-    logger = get_log(name=__name__, debug=debug)
     work_dir = cfg.work_directory
     logger.info("Running wrapped phase estimation in %s", work_dir)
 


### PR DESCRIPTION
Multiple people have expected results to be logged to a file after a workflow run, which is not done unless you specify `log_file` in the config.

Using [this example](https://github.com/mCodingLLC/VideosSampleCode/blob/master/videos/135_modern_logging/mylogger.py), I set up json logging, which looks like 

```
$ cat dolphin.log | jq
{
  "level": "INFO",
  "message": "Running wrapped phase estimation in /Users/staniewi/repos/dolphin/data/hawaii/test-new-compslc",
  "timestamp": "2024-07-05T18:03:22.326299+00:00",
  "logger": "dolphin.workflows.wrapped_phase",
  "function": "run",
  "line": 60,
  "thread_name": "MainThread"
}
```

I removed the `get_log`, which was sort of a weird antipattern, in favor of always using `logging.getLogger`

I've kept the `__name__` in the loggers, since the only other way I saw to print the full module path was to use `pathname`, which also prints the full path on your filesystem that we probably dont want