### PR TITLE
Minor changes in `spurt` config to match its naming onventions

### DIFF
--- a/src/dolphin/unwrap/_unwrap_3d.py
+++ b/src/dolphin/unwrap/_unwrap_3d.py
@@ -45,12 +45,12 @@ def unwrap_spurt(
     gen_settings = GeneralSettings(
         output_folder=output_path,
         intermediate_folder=scratchdir,
-        **options.general_settings.model_dump(by_alias=True),
+        **options.general_settings.model_dump(),
     )
 
-    tile_settings = TilerSettings(**options.tiler_settings.model_dump(by_alias=True))
-    slv_settings = SolverSettings(**options.solver_settings.model_dump(by_alias=True))
-    mrg_settings = MergerSettings(**options.merger_settings.model_dump(by_alias=True))
+    tile_settings = TilerSettings(**options.tiler_settings.model_dump())
+    slv_settings = SolverSettings(**options.solver_settings.model_dump())
+    mrg_settings = MergerSettings(**options.merger_settings.model_dump())
 
     # Using default Hop3Graph
     # TODO: this is a weird hack.. if there are 15 dates, there are 14 interferograms

--- a/src/dolphin/unwrap/_unwrap_3d.py
+++ b/src/dolphin/unwrap/_unwrap_3d.py
@@ -43,11 +43,11 @@ def unwrap_spurt(
         _mask = io.load_gdal(mask_filename)
 
     gen_settings = GeneralSettings(
-        output_folder=output_path, **options.general_settings.model_dump(by_alias=True)
+        output_folder=output_path,
+        intermediate_folder=scratchdir,
+        **options.general_settings.model_dump(by_alias=True),
     )
 
-    if scratchdir is not None:
-        gen_settings.intermediate_folder = scratchdir
     tile_settings = TilerSettings(**options.tiler_settings.model_dump(by_alias=True))
     slv_settings = SolverSettings(**options.solver_settings.model_dump(by_alias=True))
     mrg_settings = MergerSettings(**options.merger_settings.model_dump(by_alias=True))

--- a/src/dolphin/workflows/config/_unwrap_options.py
+++ b/src/dolphin/workflows/config/_unwrap_options.py
@@ -155,11 +155,19 @@ class SpurtTilerSettings(BaseModel):
 
 
 class SpurtSolverSettings(BaseModel):
-    worker_count: int = Field(
+    t_worker_count: int = Field(
         default=1,
+        alias="t_worker_count",
         description=(
             "Number of workers for temporal unwrapping in parallel. Set value to <=0 to"
             " let workflow use default workers (ncpus - 1)."
+        ),
+    )
+    s_worker_count: int = Field(
+        default=1,
+        description=(
+            "Number of workers for spatial unwrapping in parallel. Set value to <=0"
+            " to let workflow use (ncpus - 1)."
         ),
     )
     links_per_batch: int = Field(
@@ -170,25 +178,22 @@ class SpurtSolverSettings(BaseModel):
         ),
         gt=0,
     )
-    temp_cost_type: Literal["constant", "distance", "centroid"] = Field(
+    t_cost_type: Literal["constant", "distance", "centroid"] = Field(
         default="constant",
         description="Temporal unwrapping costs.",
-        alias="t_cost_type",
     )
-    temp_cost_scale: float = Field(
+    t_cost_scale: float = Field(
         default=100.0,
         description="Scale factor used to compute edge costs for temporal unwrapping.",
         gt=0.0,
-        alias="t_cost_scale",
     )
-    spatial_cost_type: Literal["constant", "distance", "centroid"] = Field(
+    s_cost_type: Literal["constant", "distance", "centroid"] = Field(
         default="constant", description="Spatial unwrapping costs.", alias="s_cost_type"
     )
-    spatial_cost_scale: float = Field(
+    s_cost_scale: float = Field(
         default=100.0,
         description="Scale factor used to compute edge costs for spatial unwrapping.",
         gt=0.0,
-        alias="s_cost_scale",
     )
 
 


### PR DESCRIPTION
The fuller variable names were not work the annoyance of having it be different/explaining the `alias` option of Pydantic.