### PR TITLE
Let `show_versions` read `importlib.metadata`, use `keep_bits`, not `lerc`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # These are the packages easily-installable through pip
-h5py >=3.6
-jax >=0.4.19
-numba >=0.56
-numpy >=1.23
-opera-utils >=0.4.1
-pydantic >=2.1
-pyproj >=3.3
-rasterio >=1.3
-ruamel_yaml >=0.15
-scipy >=1.9
-threadpoolctl >=3.0
-tqdm >=4.60
+h5py>=3.6
+jax>=0.4.19
+numba>=0.56
+numpy>=1.23
+opera-utils>=0.4.1
+pydantic>=2.1
+pyproj>=3.3
+rasterio>=1.3
+ruamel_yaml>=0.15
+scipy>=1.9
+threadpoolctl>=3.0
+tqdm>=4.60

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # These are the packages easily-installable through pip
-h5py>=3.6
-jax>=0.4.19
-numba>=0.56
-numpy>=1.23
-opera-utils>=0.4.1
-pydantic>=2.1
-pyproj>=3.3
-rasterio>=1.3
-ruamel_yaml>=0.15
-scipy>=1.9
-threadpoolctl>=3.0
-tqdm>=4.60
+h5py >=3.6
+jax >=0.4.19
+numba >=0.56
+numpy >=1.23
+opera-utils >=0.4.1
+pydantic >=2.1
+pyproj >=3.3
+rasterio >=1.3
+ruamel_yaml >=0.15
+scipy >=1.9
+threadpoolctl >=3.0
+tqdm >=4.60

--- a/src/dolphin/_show_versions.py
+++ b/src/dolphin/_show_versions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib
 import platform
+import re
 import sys
 from importlib.metadata import metadata
 from typing import Optional
@@ -79,7 +80,7 @@ def _get_deps_info() -> dict[str, Optional[str]]:
     meta = metadata("dolphin")
     # Extract dependencies from 'Requires-Dist' field
     deps = [
-        dep.split()[0]
+        re.split(r"[><=~!]", dep.split()[0])[0]
         for dep in meta.get_all("Requires-Dist", [])
         if "extra" not in dep
     ]

--- a/src/dolphin/_show_versions.py
+++ b/src/dolphin/_show_versions.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import importlib
 import platform
 import sys
+from importlib.metadata import metadata
 from typing import Optional
 
 import dolphin
@@ -38,7 +39,7 @@ def _get_version(module_name: str) -> Optional[str]:
         mod = sys.modules[module_name]
     else:
         try:
-            mod = importlib.import_module(module_name)
+            mod = importlib.import_module(module_name.replace("-", "_"))
         except ImportError:
             return None
     try:
@@ -47,23 +48,21 @@ def _get_version(module_name: str) -> Optional[str]:
         return mod.version
 
 
-def _get_opera_info() -> dict[str, Optional[str]]:
-    """Information on isce/opera specific modules.
+def _get_unwrapping_options() -> dict[str, Optional[str]]:
+    """Information on possible phase unwrapping libraries.
 
     Returns
     -------
     dict
-        dolphin / opera module information
+        module information
 
     """
-    import opera_utils
-
     return {
-        "dolphin": dolphin.__version__,
-        "opera_utils": opera_utils.__version__,
-        # optionals
+        "snaphu": _get_version("snaphu"),
+        "spurt": _get_version("spurt"),
         "isce3": _get_version("isce3"),
         "tophu": _get_version("tophu"),
+        "whirlwind": _get_version("whirlwind"),
     }
 
 
@@ -76,16 +75,18 @@ def _get_deps_info() -> dict[str, Optional[str]]:
         version information on relevant Python libraries
 
     """
+    # Get metadata for your package
+    meta = metadata("dolphin")
+    # Extract dependencies from 'Requires-Dist' field
     deps = [
-        "numpy",
-        "numba",
-        "jax",
-        "osgeo.gdal",
-        "h5py",
-        "ruamel_yaml",
-        "pydantic",
-        "setuptools",
+        dep.split()[0]
+        for dep in meta.get_all("Requires-Dist", [])
+        if "extra" not in dep
     ]
+    # Replace 'ruamel-yaml' with 'ruamel.yaml'
+    deps = [dep.replace("ruamel-yaml", "ruamel.yaml") for dep in deps]
+    # Add `osgeo` for gdal (not listed in pip requirements)
+    deps += ["osgeo.gdal"]
     return {name: _get_version(name) for name in deps}
 
 
@@ -117,14 +118,10 @@ def show_versions() -> None:
     > python -c "import dolphin; dolphin.show_versions()"
 
     """
-    from dolphin.utils import gpu_is_available
-
-    print("dolphin/isce info:")
-    _print_info_dict(_get_opera_info())
-    print("\nSystem:")
-    _print_info_dict(_get_sys_info())
+    print(f"dolphin version: {dolphin.__version__}")
     print("\nPython deps:")
     _print_info_dict(_get_deps_info())
+    print("\nSystem:")
+    _print_info_dict(_get_sys_info())
     print("optional GPU info:")
-    print(f"{gpu_is_available() = }")
     _print_info_dict(_get_gpu_info())

--- a/src/dolphin/interferogram.py
+++ b/src/dolphin/interferogram.py
@@ -659,6 +659,7 @@ def estimate_interferometric_correlations(
     out_driver: str = "GTiff",
     out_suffix: str = ".cor.tif",
     options: Sequence[str] = io.DEFAULT_TIFF_OPTIONS,
+    keep_bits: int = 10,
     num_workers: int = 3,
 ) -> list[Path]:
     """Estimate correlations for a sequence of interferograms.
@@ -670,13 +671,16 @@ def estimate_interferometric_correlations(
     ifg_paths : Sequence[Filename]
         Paths to complex interferogram files.
     window_size : tuple[int, int]
-        (row, column) size of window to use for estimate
+        (row, column) size of window to use for estimate.
     out_driver : str, optional
-        Name of output GDAL driver, by default "GTiff"
+        Name of output GDAL driver, by default "GTiff".
     out_suffix : str, optional
         File suffix to use for correlation files, by default ".cor.tif"
     options : list[str], optional
-        GDAL Creation options for the output array
+        GDAL Creation options for the output array.
+    keep_bits : int, optional
+        Number of bits to preserve in mantissa. Defaults to None.
+        Lower numbers will truncate the mantissa more and enable more compression.
     num_workers : int
         Number of threads to use for stitching in parallel.
         Default = 3
@@ -700,6 +704,8 @@ def estimate_interferometric_correlations(
         logger.debug(f"Estimating correlation for {ifg_path}, writing to {cor_path}")
         ifg = io.load_gdal(ifg_path)
         cor = estimate_correlation_from_phase(ifg, window_size=window_size)
+        if keep_bits:
+            io.round_mantissa(cor, keep_bits=keep_bits)
         io.write_arr(
             arr=cor,
             output_name=cor_path,

--- a/src/dolphin/io/_utils.py
+++ b/src/dolphin/io/_utils.py
@@ -191,7 +191,7 @@ def repack_rasters(
         Number of threads to use (default is 4).
     keep_bits : int, optional
         Number of bits to preserve in mantissa. Defaults to None.
-        Lower numbers will truncate the mantissa more and enable more compression
+        Lower numbers will truncate the mantissa more and enable more compression.
     **output_options
         Creation options to pass to `get_gtiff_options`
 

--- a/src/dolphin/workflows/stitching_bursts.py
+++ b/src/dolphin/workflows/stitching_bursts.py
@@ -11,7 +11,7 @@ from dolphin._log import log_runtime
 from dolphin._overviews import ImageType, create_image_overviews, create_overviews
 from dolphin._types import Bbox
 from dolphin.interferogram import estimate_interferometric_correlations
-from dolphin.io._utils import _format_for_gdal, get_gtiff_options
+from dolphin.io._utils import repack_raster
 
 from .config import OutputOptions
 
@@ -92,14 +92,10 @@ def run(
     )
     stitched_ifg_paths = list(date_to_ifg_path.values())
 
-    cor_create_options = _format_for_gdal(
-        get_gtiff_options(max_error=0.005, compression_type="lerc_deflate", predictor=3)
-    )
     # Estimate the interferometric correlation from the stitched interferogram
     interferometric_corr_paths = estimate_interferometric_correlations(
         stitched_ifg_paths,
         window_size=corr_window_size,
-        options=cor_create_options,
         num_workers=num_workers,
     )
 
@@ -111,8 +107,8 @@ def run(
         driver="GTiff",
         out_bounds=out_bounds,
         out_bounds_epsg=output_options.bounds_epsg,
-        options=cor_create_options,
     )
+    repack_raster(stitched_temp_coh_file, keep_bits=10)
 
     # Stitch the looked PS files
     stitched_ps_file = stitched_ifg_dir / "ps_mask_looked.tif"
@@ -127,9 +123,6 @@ def run(
     )
 
     # Stitch the amp dispersion files
-    amp_create_options = _format_for_gdal(
-        get_gtiff_options(max_error=0.005, compression_type="lerc_deflate", predictor=3)
-    )
     stitched_amp_disp_file = stitched_ifg_dir / "amp_dispersion_looked.tif"
     stitching.merge_images(
         amp_dispersion_list,
@@ -137,8 +130,8 @@ def run(
         driver="GTiff",
         out_bounds=out_bounds,
         out_bounds_epsg=output_options.bounds_epsg,
-        options=amp_create_options,
     )
+    repack_raster(stitched_temp_coh_file, keep_bits=10)
 
     stitched_shp_count_file = stitched_ifg_dir / "shp_counts.tif"
     stitching.merge_images(

--- a/tests/test_show_versions.py
+++ b/tests/test_show_versions.py
@@ -13,12 +13,10 @@ def test_get_deps_info():
     deps_info = _get_deps_info()
 
     assert "osgeo.gdal" in deps_info
-    assert "numba" in deps_info
     assert "numpy" in deps_info
     assert "pydantic" in deps_info
     assert "ruamel_yaml" in deps_info
     assert "h5py" in deps_info
-    assert "setuptools" in deps_info
 
 
 def test_show_versions(capsys):


### PR DESCRIPTION
Now the `show_versions` doesn't have to duplicate the list of dependencies (which was out of date).

Also fixes Ryan's problem,
```
RuntimeError: Cannot create TIFF file due to missing codec for lerc_deflate.
```