### PR TITLE
Add whirlwind unwrapper

### DIFF
--- a/.github/workflows/test-build-push.yml
+++ b/.github/workflows/test-build-push.yml
@@ -28,6 +28,10 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
+    # Add GITHUB_TOKEN permissions to clone private repos.
+    # TODO Remove this when whirlwind becomes public.
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,6 +45,11 @@ jobs:
           condarc: |
             channels:
               - conda-forge
+      # XXX The whirlwind repo is currently private and requires a C++20 compiler so
+      # let's install it separately from other dependencies.
+      - name: Install whirlwind
+          micromamba install -c conda-forge --override-channels cxx-compiler
+          pip install git+https://${{ secrets.GITHUB_TOKEN }}@github.com/isce-framework/whirlwind.git@main
       - name: Install
         run: |
           pip install --no-deps "snaphu>=0.4.0" "opera-utils>=0.4.1" git+https://github.com/isce-framework/tophu@main

--- a/src/dolphin/_show_versions.py
+++ b/src/dolphin/_show_versions.py
@@ -64,6 +64,7 @@ def _get_opera_info() -> dict[str, Optional[str]]:
         # optionals
         "isce3": _get_version("isce3"),
         "tophu": _get_version("tophu"),
+        "whirlwind": _get_version("whirlwind"),
     }
 
 

--- a/src/dolphin/unwrap/__init__.py
+++ b/src/dolphin/unwrap/__init__.py
@@ -3,3 +3,4 @@ from ._post_process import *
 from ._snaphu_py import *
 from ._tophu import *
 from ._unwrap import *
+from ._whirlwind import *

--- a/src/dolphin/unwrap/_isce3.py
+++ b/src/dolphin/unwrap/_isce3.py
@@ -28,7 +28,7 @@ def unwrap_isce3(
     ccl_nodata: int = DEFAULT_CCL_NODATA,
     zero_where_masked: bool = False,
 ) -> tuple[Path, Path]:
-    """Unwrap a single interferogram using snaphu, isce3, or tophu.
+    """Unwrap a single interferogram using isce3 or tophu.
 
     Parameters
     ----------
@@ -49,7 +49,7 @@ def unwrap_isce3(
         Nodata value to use in output connected component raster
     unwrap_method : UnwrapMethod or str, optional, default = "phass"
         Choice of unwrapping algorithm to use.
-        Choices: {"icu", "phass"} (snaphu is done by snaphu_pu)
+        Choices: {"icu", "phass"} (snaphu is done by snaphu-py)
 
     Returns
     -------

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -32,7 +32,7 @@ def unwrap_snaphu_py(
     cost: str = "smooth",
     scratchdir: Optional[Filename] = None,
 ) -> tuple[Path, Path]:
-    """Unwrap an interferogram using at multiple scales using `tophu`.
+    """Unwrap an interferogram using `SNAPHU`.
 
     Parameters
     ----------
@@ -42,8 +42,6 @@ def unwrap_snaphu_py(
         Path to input correlation file.
     unw_filename : Filename
         Path to output unwrapped phase file.
-    downsample_factor : tuple[int, int]
-        Downsample the interferograms by this factor to unwrap faster, then upsample
     nlooks : float
         Effective number of looks used to form the input correlation data.
     ntiles : tuple[int, int], optional
@@ -63,7 +61,7 @@ def unwrap_snaphu_py(
         Set wrapped phase/correlation to 0 where mask is 0 before unwrapping.
         If not mask is provided, this is ignored.
         By default True.
-    unw_nodata : float , optional.
+    unw_nodata : float, optional
         If providing `unwrap_callback`, provide the nodata value for your
         unwrapping function.
     ccl_nodata : float, optional

--- a/src/dolphin/unwrap/_whirlwind.py
+++ b/src/dolphin/unwrap/_whirlwind.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import logging
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+from dolphin._types import Filename
+from dolphin.io._core import DEFAULT_TIFF_OPTIONS_RIO
+from dolphin.utils import full_suffix
+
+from ._constants import CONNCOMP_SUFFIX, DEFAULT_CCL_NODATA, DEFAULT_UNW_NODATA
+from ._utils import _zero_from_mask
+
+__all__ = [
+    "unwrap_whirlwind",
+]
+
+
+logger = logging.getLogger(__name__)
+
+
+def unwrap_whirlwind(
+    ifg_filename: Filename,
+    corr_filename: Filename,
+    unw_filename: Filename,
+    nlooks: float,
+    mask_file: Optional[Filename] = None,
+    zero_where_masked: bool = False,
+    unw_nodata: Optional[float] = DEFAULT_UNW_NODATA,
+    ccl_nodata: Optional[int] = DEFAULT_CCL_NODATA,
+    scratchdir: Optional[Filename] = None,
+) -> tuple[Path, Path]:
+    """Unwrap an interferogram using `whirlwind`.
+
+    Parameters
+    ----------
+    ifg_filename : Filename
+        Path to input interferogram.
+    corr_filename : Filename
+        Path to input correlation file.
+    unw_filename : Filename
+        Path to output unwrapped phase file.
+    nlooks : float
+        Effective number of looks used to form the input correlation data.
+    mask_file : Filename, optional
+        Path to binary byte mask file, by default None.
+        Assumes that 1s are valid pixels and 0s are invalid.
+    zero_where_masked : bool, optional
+        Set wrapped phase/correlation to 0 where mask is 0 before unwrapping.
+        If not mask is provided, this is ignored.
+        By default True.
+    unw_nodata : float, optional
+        If providing `unwrap_callback`, provide the nodata value for your
+        unwrapping function.
+    ccl_nodata : float, optional
+        Nodata value for the connected component labels.
+    scratchdir : Filename, optional
+        If provided, uses a scratch directory to save the intermediate files
+        during unwrapping.
+
+    Returns
+    -------
+    unw_path : Path
+        Path to output unwrapped phase file.
+    conncomp_path : Path
+        Path to output connected component label file.
+
+    """
+    import snaphu
+    import whirlwind as ww
+
+    # Create a context manager that combines other context managers -- one for each
+    # input raster file. Upon exiting the context block, each context manager in the
+    # stack will be closed in LIFO order.
+    with ExitStack() as stack:
+        if zero_where_masked and (mask_file is not None):
+            logger.info(f"Zeroing phase/corr of pixels masked in {mask_file}")
+            zeroed_ifg_file, zeroed_corr_file = _zero_from_mask(
+                ifg_filename, corr_filename, mask_file
+            )
+            igram = stack.enter_context(snaphu.io.Raster(zeroed_ifg_file))
+            corr = stack.enter_context(snaphu.io.Raster(zeroed_corr_file))
+        else:
+            igram = stack.enter_context(snaphu.io.Raster(ifg_filename))
+            corr = stack.enter_context(snaphu.io.Raster(corr_filename))
+
+        if mask_file is None:
+            mask = None
+        else:
+            mask = stack.enter_context(snaphu.io.Raster(mask_file))
+
+        logger.info("Unwrapping using whirlwind")
+        unw = ww.unwrap(igram, corr, nlooks, mask=mask)
+
+        logger.info("Writing unwrapped phase to raster file")
+        with snaphu.io.Raster.create(
+            unw_filename,
+            like=igram,
+            nodata=unw_nodata,
+            dtype=np.float32,
+            **DEFAULT_TIFF_OPTIONS_RIO,
+        ) as unw_raster:
+            unw_raster[:, :] = unw
+
+        unw_suffix = full_suffix(unw_filename)
+        cc_filename = str(unw_filename).replace(unw_suffix, CONNCOMP_SUFFIX)
+
+        # XXX Whirlwind does not yet provide connected components. Instead, grow
+        # connected components using SNAPHU's 'SMOOTH' cost function for now.
+        logger.info("Growing connected component labels using SNAPHU")
+        with snaphu.io.Raster.create(
+            cc_filename,
+            like=igram,
+            nodata=ccl_nodata,
+            dtype=np.uint16,
+            **DEFAULT_TIFF_OPTIONS_RIO,
+        ) as conncomp:
+            snaphu.grow_conncomps(
+                unw=unw,
+                corr=corr,
+                nlooks=nlooks,
+                mask=mask,
+                cost="smooth",
+                scratchdir=scratchdir,
+                conncomp=conncomp,
+            )
+
+    if zero_where_masked and (mask_file is not None):
+        logger.info(f"Zeroing unw/conncomp of pixels masked in {mask_file}")
+        return _zero_from_mask(unw_filename, cc_filename, mask_file)
+
+    return Path(unw_filename), Path(cc_filename)

--- a/src/dolphin/workflows/config/_enums.py
+++ b/src/dolphin/workflows/config/_enums.py
@@ -24,6 +24,7 @@ class UnwrapMethod(str, Enum):
     ICU = "icu"
     PHASS = "phass"
     SPURT = "spurt"
+    WHIRLWIND = "whirlwind"
 
 
 class CallFunc(str, Enum):

--- a/tests/test_unwrap.py
+++ b/tests/test_unwrap.py
@@ -11,6 +11,7 @@ from dolphin.workflows import SpurtOptions, TophuOptions, UnwrapMethod, UnwrapOp
 
 TOPHU_INSTALLED = importlib.util.find_spec("tophu") is not None
 SPURT_INSTALLED = importlib.util.find_spec("spurt") is not None
+WHIRLWIND_INSTALLED = importlib.util.find_spec("whirlwind") is not None
 
 
 # Dataset has no geotransform, gcps, or rpcs. The identity matrix will be returned.
@@ -303,6 +304,23 @@ class TestSpurt:
 
         to = SpurtOptions()
         unwrap_options = UnwrapOptions(unwrap_method="phass", tophu_options=to)
+        out_path, conncomp_path = dolphin.unwrap.unwrap(
+            ifg_filename=raster_100_by_200,
+            corr_filename=corr_raster,
+            unw_filename=unw_filename,
+            unwrap_options=unwrap_options,
+            nlooks=1,
+        )
+        assert out_path.exists()
+        assert conncomp_path.exists()
+
+
+@pytest.mark.skipif(not WHIRLWIND_INSTALLED, reason="whirlwind package not installed")
+class TestWhirlwind:
+    def test_unwrap_whirlwind(self, tmp_path, raster_100_by_200, corr_raster):
+        unw_filename = tmp_path / "whirlwind-unwrapped.unw.tif"
+
+        unwrap_options = UnwrapOptions(unwrap_method="whirlwind")
         out_path, conncomp_path = dolphin.unwrap.unwrap(
             ifg_filename=raster_100_by_200,
             corr_filename=corr_raster,


### PR DESCRIPTION
Adds whirlwind as an alternative phase unwrapping option.

The whirlwind repo is still private currently, but should be accessible to isce-framework members and to the CI. Adding it to dolphin will allow for valuable initial testing and comparison to other unwrappers. The remaining functionality in dolphin should be unaffected for folks who don't have whirlwind installed.

Another limitation is that whirlwind currently does not provide a connected components layer. For now, the whirlwind wrapper also depends on snaphu-py to compute connected components (as well as for raster I/O).