### PR TITLE
Update `average_rasters`, add ability to make weighted average

### DIFF
--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -593,6 +593,7 @@ def create_average(
     block_shape: tuple[int, int] = (512, 512),
     num_threads: int = 5,
     average_func: Callable[[ArrayLike, int], np.ndarray] = np.nanmean,
+    mask_average_func: Callable[[ArrayLike, int], np.ndarray] = np.any,
     read_masked: bool = False,
 ) -> None:
     """Average all images in `file_list` to create a 2D image in `output_file`.
@@ -612,6 +613,11 @@ def create_average(
     average_func : Callable[[ArrayLike, int], np.ndarray], optional
         The function to use to average the images.
         Default is `np.nanmean`, which calls `np.nanmean(arr, axis=0)` on each block.
+    mask_average_func : Callable[[ArrayLike, int], np.ndarray], optional
+        If `read_masked` is true, the function to use to average the masks.
+        Default is `np.any`, which calls `np.any(masks, axis=0)` on each block
+        and masks *any* pixel that is masked in one of the images.
+        Use `np.all` to have more valid pixels (a smaller masked region).
     read_masked : bool, optional
         If True, reads the data as a masked array based on the rasters' nodata values.
         Default is False.
@@ -623,6 +629,9 @@ def create_average(
     ) -> tuple[slice, slice, np.ndarray]:
         chunk = readers[0][:, rows, cols]
         out_chunk = average_func(chunk, 0), rows, cols
+        if isinstance(chunk, np.ma.MaskedArray):
+            mask = mask_average_func(chunk.mask, 0)
+            out_chunk = np.ma.MaskedArray(data=out_chunk, mask=mask)
         return out_chunk
 
     writer = io.BackgroundRasterWriter(output_file, like_filename=file_list[0])

--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -4,7 +4,7 @@ import logging
 import shutil
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Callable, Optional, Protocol, Sequence, TypeVar
+from typing import Callable, Optional, Sequence, TypeVar
 
 import jax.numpy as jnp
 import numpy as np
@@ -579,12 +579,6 @@ def create_velocity(
     if add_overviews:
         logger.info("Creating overviews for velocity image")
         create_overviews([output_file])
-
-
-class AverageFunc(Protocol):
-    """Protocol for temporally averaging a block of data."""
-
-    def __call__(self, ArrayLike, axis: int) -> ArrayLike: ...
 
 
 def create_average(

--- a/src/dolphin/workflows/sequential.py
+++ b/src/dolphin/workflows/sequential.py
@@ -7,16 +7,13 @@ from __future__ import annotations
 
 import logging
 from itertools import chain
-from os import fspath
 from pathlib import Path
 from typing import Optional
 
-from osgeo_utils import gdal_calc
-
-from dolphin import io
 from dolphin._types import Filename
 from dolphin.io import VRTStack
 from dolphin.stack import MiniStackPlanner
+from dolphin.timeseries import create_average
 
 from .config import ShpMethod
 from .single import run_wrapped_phase_single
@@ -132,8 +129,8 @@ def run_wrapped_phase_sequential(
 
     # we can pass the list of files to gdal_calc, which interprets it
     # as a multi-band file
-    _average_rasters(temp_coh_files, output_temp_coh_file, "Float32")
-    _average_rasters(shp_count_files, output_shp_count_file, "Int16")
+    create_average(temp_coh_files, output_file=output_temp_coh_file)
+    create_average(shp_count_files, output_file=output_shp_count_file)
 
     # Combine the separate SLC output lists into a single list
     all_slc_files = list(chain.from_iterable(output_slc_files))
@@ -162,22 +159,3 @@ def _get_outputs_from_folder(
     # Currently ignoring to not stitch:
     # eigenvalues, estimator, avg_coh
     return cur_output_files, cur_comp_slc_file, temp_coh_file, shp_count_file
-
-
-def _average_rasters(file_list: list[Path], outfile: Path, output_type: str):
-    if len(file_list) == 1:
-        file_list[0].rename(outfile)
-        return
-
-    logger.info(f"Averaging {len(file_list)} files into {outfile}")
-    gdal_calc.Calc(
-        NoDataValue=0,
-        format="GTiff",
-        outfile=fspath(outfile),
-        type=output_type,
-        quiet=True,
-        overwrite=True,
-        creation_options=io.DEFAULT_TIFF_OPTIONS,
-        A=file_list,
-        calc="numpy.nanmean(A, axis=0)",
-    )

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -222,6 +222,17 @@ class TestVelocity:
         npt.assert_allclose(velocities, expected_velo, atol=1e-5)
 
 
+class TestCreateAverage:
+    def test_basic(self, tmp_path, slc_file_list, slc_stack):
+        output_file = tmp_path / "average.tif"
+        timeseries.create_average(
+            file_list=slc_file_list, output_file=output_file, num_threads=1
+        )
+        computed = io.load_gdal(output_file)
+        expected = np.average(slc_stack, axis=0)
+        npt.assert_allclose(computed, expected)
+
+
 if __name__ == "__main__":
     sar_dates = make_sar_dates()
     sar_phases = make_sar_phases(sar_dates)


### PR DESCRIPTION
- No need to use `gdal_calc` if we have this function
- For averaging temporal coherences with different sizes, we may want to apply weights to not overstate the coherence (if, e.g., we had a ministack of 2 and everything has coherence = 1)