### PR TITLE
Interleave GTiffs by band

### DIFF
--- a/src/dolphin/io/_core.py
+++ b/src/dolphin/io/_core.py
@@ -58,6 +58,7 @@ DEFAULT_TIFF_OPTIONS_RIO = {
     "zlevel": 4,
     "bigtiff": "yes",
     "tiled": "yes",
+    "interleave": "band",
     "blockxsize": DEFAULT_TILE_SHAPE[1],
     "blockysize": DEFAULT_TILE_SHAPE[0],
 }


### PR DESCRIPTION
size difference from better interleave for 2-band compressed:
```
ls -lh
305M Jul 23 14:28 compressed_interleave_by_band.tif
551M Jul 23 13:54 compressed_20170606_20171227_20180625.tif
```