### PR TITLE
Improve code for transferring unwrapped phase ambiguities

### DIFF
--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -445,7 +445,7 @@ def unwrap(
         )
         unw_arr = io.load_gdal(unwrapper_unw_filename, masked=True).filled(unw_nodata)
 
-        final_arr = transfer_ambiguities(unw_arr, np.angle(ifg))
+        final_arr = transfer_ambiguities(np.angle(ifg), unw_arr)
         final_arr[ifg.mask] = unw_nodata
 
         io.write_arr(


### PR DESCRIPTION
Dolphin may do some interferogram pre-processing, such as interpolation and/or Goldstein filtering, prior to unwrapping. In order to preserve congruence with the original wrapped phase values, the ambiguity numbers for the initial unwrapped result are then transferred onto the original wrapped phase in order to form the final unwrapped phase.

The current strategy for estimating the ambiguity numbers is to compute the difference between the unwrapped phase and the pre-processed (i.e. interpolated, filtered) wrapped phase values. However, we found that this sometimes introduces phase discontinuities near fringe boundaries.

The new strategy introduced in this PR is to compute the difference between the unwrapped phase and the \*original\* wrapped phase data and then round that to the nearest multiple of 2pi in order to form the ambiguity numbers.