### PR TITLE
Move mask loading function into `masking.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ conda activate dolphin-env
 python -m pip install .
 ```
 
-Dolphin can also take advantage of CUDA-compatible GPUs for faster processing. [See the docs](dolphin-insar.readthedocs.io/gpu-setup.md) for installation instructions and configuration.
+Dolphin can also take advantage of CUDA-compatible GPUs for faster processing. [See the docs](https://dolphin-insar.readthedocs.io/en/latest/gpu-setup) for installation instructions and configuration.
 
 ## Usage
 

--- a/docs/gpu-setup.md
+++ b/docs/gpu-setup.md
@@ -1,7 +1,7 @@
 # GPU setup
 
 If you have access to a GPU with CUDA support, you can gain a considerable processing speedup with `dolphin`.
-We use both [Numba](https://github.com/numba/numba/) and [JAX](jax.readthedocs.io/), which each have slightly different setups:
+We use both [Numba](https://github.com/numba/numba/) and [JAX](https://jax.readthedocs.io/), which each have slightly different setups:
 
 - Numba instructions: https://numba.readthedocs.io/en/stable/cuda/overview.html#software
 - JAX instructions: https://jax.readthedocs.io/en/latest/installation.html#nvidia-gpu

--- a/src/dolphin/workflows/config/_displacement.py
+++ b/src/dolphin/workflows/config/_displacement.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import Annotated, Any, Optional
 
-from opera_utils._dates import get_dates, sort_files_by_date
+from opera_utils import get_dates, sort_files_by_date
 from pydantic import (
     BaseModel,
     ConfigDict,

--- a/src/dolphin/workflows/single.py
+++ b/src/dolphin/workflows/single.py
@@ -15,6 +15,7 @@ from dolphin import io, shp
 from dolphin._decorators import atomic_output
 from dolphin._types import Filename, HalfWindow, Strides
 from dolphin.io import EagerLoader, StridedBlockManager, VRTStack
+from dolphin.masking import load_mask_as_numpy
 from dolphin.phase_link import PhaseLinkRuntimeError, compress, run_phase_linking
 from dolphin.ps import calc_ps_block
 from dolphin.stack import MiniStackInfo
@@ -307,18 +308,9 @@ def _get_nodata_mask(
     ncols: int,
 ) -> np.ndarray:
     if mask_file is not None:
-        # The mask file will by -2s at invalid data, 1s at good
-        nodata_mask = io.load_gdal(mask_file, masked=True).astype(bool).filled(False)
-        # invert the mask so -1s are the missing data pixels
-        nodata_mask = ~nodata_mask
-        # check middle pixel
-        if nodata_mask[nrows // 2, ncols // 2]:
-            logger.warning(f"{mask_file} is True at {nrows//2, ncols//2}")
-            logger.warning("Proceeding without the nodata mask.")
-            nodata_mask = np.zeros((nrows, ncols), dtype=bool)
+        return load_mask_as_numpy(mask_file)
     else:
-        nodata_mask = np.zeros((nrows, ncols), dtype=bool)
-    return nodata_mask
+        return np.zeros((nrows, ncols), dtype=bool)
 
 
 def _get_ps_mask(

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from dolphin import io, masking
+
+
+@pytest.fixture()
+def mask_files(tmp_path):
+    """Make series of files offset in lat/lon."""
+    shape = (9, 9)
+
+    all_masked = np.zeros(shape, dtype="uint8")
+    file_list = []
+    for i in range(shape[0]):
+        fname = tmp_path / f"mask_{i}.tif"
+        arr = all_masked.copy()
+        # make first third, then middle, then end "good" pixels
+        rows = slice(3 * i, 3 * (i + 1))
+        arr[rows, :] = 1
+        io.write_arr(arr=arr, output_name=fname)
+        file_list.append(Path(fname))
+
+    return file_list
+
+
+@pytest.mark.parametrize("convention", [None, masking.MaskConvention.ZERO_IS_NODATA])
+def test_combine_mask_files(mask_files, convention):
+    output_file = mask_files[0].parent / "combined.tif"
+    masking.combine_mask_files(
+        mask_files=mask_files,
+        output_file=output_file,
+        input_conventions=convention,
+    )
+    expected = np.zeros((9, 9), dtype="uint8")
+    np.testing.assert_array_equal(expected, io.load_gdal(output_file))
+
+
+def test_load_mask_as_numpy(mask_files):
+    arr = masking.load_mask_as_numpy(mask_files[0])
+    expected = np.ones((9, 9), dtype=bool)
+    expected[:3] = False
+    np.testing.assert_array_equal(arr, expected)


### PR DESCRIPTION
- creates `load_mask_as_numpy` in `masking`
- Fixes `combine_mask_files` to use `io.write_arr` rather than `gdal` bindings. changes convention default to be all `ZERO_IS_NODATA`