### PR TITLE
Simplify `filter_long_wavelength` to use `np.pad(..., mode="reflect")`

### DIFF
--- a/src/dolphin/filtering.py
+++ b/src/dolphin/filtering.py
@@ -6,7 +6,8 @@ from scipy import fft, ndimage
 def filter_long_wavelength(
     unwrapped_phase: ArrayLike,
     correlation: ArrayLike,
-    mask_cutoff: float = 0.5,
+    correlation_cutoff: float = 0.5,
+    connected_component_labels: ArrayLike | None = None,
     wavelength_cutoff: float = 50 * 1e3,
     pixel_spacing: float = 30,
     workers: int = 1,
@@ -19,11 +20,14 @@ def filter_long_wavelength(
         Unwrapped interferogram phase to filter.
     correlation : Arraylike, 2D
         Array of interferometric correlation from 0 to 1.
-    mask_cutoff: float
+    correlation_cutoff : float
         Threshold to use on `correlation` so that pixels where
-        `correlation[i, j] > mask_cutoff` are used and the rest are ignored.
+        `correlation[i, j] > correlation_cutoff` are used and the rest are ignored.
         The default is 0.5.
-    wavelength_cutoff: float
+    connected_component_labels : ArrayLike, optional
+        Integer labels of connected components from the unwrapped interferogram.
+        If provided, ignores pixels with label 0.
+    wavelength_cutoff : float
         Spatial wavelength threshold to filter the unwrapped phase.
         Signals with wavelength longer than 'wavelength_cutoff' are filtered out.
         The default is 50*1e3 (m).
@@ -42,29 +46,45 @@ def filter_long_wavelength(
 
     """
     nrow, ncol = correlation.shape
-    mask = correlation > mask_cutoff
-    mask_boundary = ~(correlation == 0)
+    good_pixel_mask = correlation > correlation_cutoff
+    non_boundary_mask = ~(correlation == 0)
 
-    plane = fit_ramp_plane(unwrapped_phase, mask)
+    if connected_component_labels is not None:
+        good_pixel_mask = good_pixel_mask & (connected_component_labels != 0)
 
-    unw_ifg_interp = np.where(mask & mask_boundary, unwrapped_phase, plane)
+    unw0 = np.nan_to_num(unwrapped_phase)
+    unw_valid_mask = unw0 != 0
+    total_valid_mask = unw_valid_mask & good_pixel_mask
+
+    # Shift to be zero mean, then reset the borders to 0
+    offset = np.mean(unw0[total_valid_mask])
+    unw0 -= offset
+    unw0[~total_valid_mask] = 0
+
+    plane = fit_ramp_plane(unw0, total_valid_mask)
+
+    unw_ifg_interp = np.where(total_valid_mask, unw0, plane)
 
     # Pad the array with edge values
-    pad_width = ((nrow // 2, nrow // 2), (ncol // 2, ncol // 2))
+    pad_rows = nrow // 4
+    pad_cols = ncol // 4
     # See here for illustration of `mode="reflect"`
     # https://scikit-image.org/docs/stable/auto_examples/transform/plot_edge_modes.html#interpolation-edge-modes
-    padded = np.pad(unw_ifg_interp, pad_width, mode="reflect")
+    padded = np.pad(
+        unw_ifg_interp, ((pad_rows, pad_rows), (pad_cols, pad_cols)), mode="reflect"
+    )
 
     sigma = _compute_filter_sigma(wavelength_cutoff, pixel_spacing, cutoff_value=0.5)
     # Apply Gaussian filter
     input_ = fft.fft2(padded, workers=workers)
     result = ndimage.fourier_gaussian(input_, sigma=sigma)
-    result = np.fft.ifft2(result).real.astype(unwrapped_phase.dtype)
+    # Make sure to only take the real part (ifft returns complex)
+    result = fft.ifft2(result, workers=workers).real.astype(unwrapped_phase.dtype)
 
     # Crop back to original size
-    lowpass_filtered = result[nrow // 2 : -nrow // 2, ncol // 2 : -ncol // 2]
+    lowpass_filtered = result[pad_rows:-pad_rows, pad_cols:-pad_cols]
 
-    filtered_ifg = unwrapped_phase - lowpass_filtered * mask_boundary
+    filtered_ifg = unw0 - lowpass_filtered * non_boundary_mask
 
     return filtered_ifg
 

--- a/src/dolphin/filtering.py
+++ b/src/dolphin/filtering.py
@@ -3,12 +3,13 @@ from numpy.typing import ArrayLike
 from scipy import fft, ndimage
 
 
-def filter_long_wavelength_old(
+def filter_long_wavelength(
     unwrapped_phase: ArrayLike,
     correlation: ArrayLike,
     mask_cutoff: float = 0.5,
     wavelength_cutoff: float = 50 * 1e3,
     pixel_spacing: float = 30,
+    workers: int = 1,
 ) -> np.ndarray:
     """Filter out signals with spatial wavelength longer than a threshold.
 
@@ -29,6 +30,9 @@ def filter_long_wavelength_old(
     pixel_spacing : float
         Pixel spatial spacing. Assume same spacing for x, y axes.
         The default is 30 (m).
+    workers : int
+        Number of `fft` workers to use for `scipy.fft.fft2`.
+        Default is 1.
 
     Returns
     -------
@@ -53,7 +57,7 @@ def filter_long_wavelength_old(
 
     sigma = _compute_filter_sigma(wavelength_cutoff, pixel_spacing, cutoff_value=0.5)
     # Apply Gaussian filter
-    input_ = fft.fft2(padded, workers=6)
+    input_ = fft.fft2(padded, workers=workers)
     result = ndimage.fourier_gaussian(input_, sigma=sigma)
     result = np.fft.ifft2(result).real.astype(unwrapped_phase.dtype)
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -8,9 +8,12 @@ def test_filter_long_wavelegnth():
     y, x = np.ogrid[-3:3:512j, -3:3:512j]
     unw_ifg = np.pi * (x + y)
     corr = np.ones(unw_ifg.shape, dtype=np.float32)
+    bad_pixel_mask = corr < 0.5
 
     # Filtering
-    filtered_ifg = filtering.filter_long_wavelength(unw_ifg, corr, pixel_spacing=300)
+    filtered_ifg = filtering.filter_long_wavelength(
+        unw_ifg, bad_pixel_mask=bad_pixel_mask, pixel_spacing=300
+    )
     np.testing.assert_allclose(
         filtered_ifg[10:-10, 10:-10],
         np.zeros(filtered_ifg[10:-10, 10:-10].shape),


### PR DESCRIPTION
We can get a temporarily working version that doesn't quite do the edges the same, but works to fix #371 . This just uses `np.pad` with `mode="reflect"`. It doesn't 

 https://scikit-image.org/docs/stable/auto_examples/transform/plot_edge_modes.html#interpolation-edge-modes has an illustration of what the pad modes look like. I think we were going for either "reflect" or "symmetric".

Also, we were using a `sigma` of ~200 pixels, which is kinda slow for our huge 7000x9000 pixel images. Using [fourier_gaussian](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.fourier_gaussian.html#scipy.ndimage.fourier_gaussian) should be a bit quicker, looks like is ~2 minutes in this PR vs ~5 minutes in main

```
In [42]: %time filt_main = filtering.filter_long_wavelength_seyeon(np.nan_to_num(unw), np.nan_to_num(cor))
CPU times: user 3min 55s, sys: 8.17 s, total: 4min 3s
Wall time: 5min 10s

In [43]: %time filt_new = filtering.filter_long_wavelength(unw, cor, workers=3)
CPU times: user 1min 43s, sys: 37.1 s, total: 2min 20s
Wall time: 2min 8s
```

Difference for one test .unw file:
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/c4076733-7e7a-42c5-bec0-156b4a5a88a5">



(note- the current version can't have nans or the filter size gets cut off:)
<img width="1504" alt="image" src="https://github.com/user-attachments/assets/f8f36037-0944-4ebf-be67-3667e425bea4">
