### PR TITLE
Skip zero raster output by timeseries inversions

### DIFF
--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -140,11 +140,11 @@ def run(
         logger.info("Estimating phase velocity")
         if velocity_file is None:
             velocity_file = Path(output_dir) / "velocity.tif"
+
         create_velocity(
             unw_file_list=inverted_phase_paths,
             output_file=velocity_file,
             reference=reference,
-            date_list=sar_dates,
             cor_file_list=cor_file_list,
             cor_threshold=correlation_threshold,
             num_threads=num_threads,

--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -129,17 +129,6 @@ def run(
             if not target.exists():  # Check to prevent overwriting
                 shutil.copy(p, target)
             inverted_phase_paths.append(target)
-        # Make extra "0" raster so that the number of rasters matches len(sar_dates)
-        ref_raster = Path(output_dir) / (
-            utils.format_dates(sar_dates[0], sar_dates[0]) + ".tif"
-        )
-        io.write_arr(
-            arr=None,
-            output_name=ref_raster,
-            like_filename=inverted_phase_paths[0],
-            nodata=0,
-        )
-        inverted_phase_paths.append(ref_raster)
 
     if run_velocity:
         #  We can't pass the correlations after an inversion- the numbers don't match
@@ -275,7 +264,7 @@ def invert_stack(
     -------
     phi : np.array 3D
         The estimated phase for each SAR acquisition
-        Shape is (n_sar_dates, n_rows, n_cols)
+        Shape is (n_sar_dates - 1, n_rows, n_cols)
     residuals : np.array 2D
         Sums of squared residuals: Squared Euclidean 2-norm for `dphi - A @ x`
         Shape is (n_rows, n_cols)
@@ -308,8 +297,6 @@ def invert_stack(
         # Reshape the residuals to be 2D
         residuals = residuals[0]
 
-    # Add 0 for the reference date to the front
-    phase = jnp.concatenate([jnp.zeros((1, n_rows, n_cols)), phase], axis=0)
     return phase, residuals
 
 
@@ -710,8 +697,9 @@ def invert_unw_network(
     sar_dates = sorted(set(flatten(ifg_tuples)))
     ref_date = sar_dates[0]
     suffix = ".tif"
+    # Create the `n_sar_dates - 1` output files (skipping the 0 reference raster)
     out_paths = [
-        Path(output_dir) / (format_dates(ref_date, d) + suffix) for d in sar_dates
+        Path(output_dir) / (format_dates(ref_date, d) + suffix) for d in sar_dates[1:]
     ]
     if all(p.exists() for p in out_paths):
         logger.info("All output files already exist, skipping inversion")

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -116,9 +116,9 @@ class TestInvert:
         sar_dates, sar_phases, ifg_date_pairs, ifgs = data
 
         phi_stack, residuals = timeseries.invert_stack(A, ifgs)
-        assert phi_stack.shape == sar_phases.shape
-        assert residuals.shape == sar_phases.shape[1:]
-        npt.assert_allclose(phi_stack, sar_phases, atol=1e-5)
+        assert phi_stack.shape == sar_phases[1:].shape
+        assert residuals.shape == sar_phases[0].shape
+        npt.assert_allclose(phi_stack, sar_phases[1:], atol=1e-5)
         npt.assert_array_less(residuals, 1e-5)
 
     def test_weighted_stack(self, data, A):
@@ -126,12 +126,12 @@ class TestInvert:
 
         weights = np.ones_like(ifgs)
         phi, residuals = timeseries.invert_stack(A, ifgs, weights)
-        assert phi.shape[0] == len(sar_dates)
-        npt.assert_allclose(phi, sar_phases, atol=1e-5)
+        assert phi.shape[0] == len(sar_dates) - 1
+        npt.assert_allclose(phi, sar_phases[1:], atol=1e-5)
         # Here there is no noise, so it's over determined
         weights[1, :, :] = 0
         phi2, residuals2 = timeseries.invert_stack(A, ifgs, weights)
-        npt.assert_allclose(phi2, sar_phases, atol=1e-5)
+        npt.assert_allclose(phi2, sar_phases[1:], atol=1e-5)
         npt.assert_allclose(residuals2, residuals, atol=1e-5)
 
     def test_remove_row_vs_weighted(self, data, A):
@@ -188,7 +188,7 @@ class TestInvert:
         # Check results
         solved_stack = io.RasterStackReader.from_file_list(out_files)[:, :, :]
         sar_phases = data[1]
-        npt.assert_allclose(solved_stack, sar_phases, atol=1e-5)
+        npt.assert_allclose(solved_stack, sar_phases[1:], atol=1e-5)
 
 
 class TestVelocity:


### PR DESCRIPTION
- The numpy array is now smaller
- The empty `20200101_20200101` raster is skipped