### PR TITLE
Fix `displacement.run` to avoid troposphere computation with empty list

### DIFF
--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -302,7 +302,7 @@ def run(
                 "DEM file is not given, skip estimating tropospheric corrections."
             )
         else:
-            if cfg.correction_options.troposphere_files is not None:
+            if cfg.correction_options.troposphere_files:
                 from dolphin.atmosphere import estimate_tropospheric_delay
 
                 assert timeseries_paths is not None


### PR DESCRIPTION
As pointed out by @collinss-jpl , this used to not check for `None`. Since the default initializer is an empty list, this fails after loading the yaml and creating `[]`.
