### PR TITLE
Add config option to avoid PS pixels during phase linking

### DIFF
--- a/src/dolphin/filtering.py
+++ b/src/dolphin/filtering.py
@@ -165,7 +165,7 @@ def filter_rasters(
         List of paths to correlation files
         Passing None skips filtering on correlation.
     conncomp_filenames : list[Path] | None
-        List of paths to connected component files, filters any 0 labelled pixels.
+        List of paths to connected component files, filters any 0 labeled pixels.
         Passing None skips filtering on connected component labels.
     temporal_coherence_filename : Path | None
         Path to the temporal coherence file for masking.

--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -104,6 +104,14 @@ class PhaseLinkingOptions(BaseModel, extra="forbid"):
         gt=0.0,
         lt=1.0,
     )
+    mask_input_ps: bool = Field(
+        False,
+        description=(
+            "If True, pixels labeled as PS will get set to NaN during phase linking to"
+            " avoid summing their phase. Default of False means that the SHP algorithm"
+            " will decide if a pixel should be included, regardless of its PS label."
+        ),
+    )
     baseline_lag: Optional[int] = Field(
         None,
         gt=0,


### PR DESCRIPTION
Background on why this was the default before: For the simple "rect" SHP finder (which is no SHP finding- just averaging in a rectangular window like basic multilooking), the results can sometimes look much better if you mask out very bright pixels (which dominate the sum in a window).

Since the normal default uses the GLRT SHP algorithm, that algorithm should take care of this problem on its own; users picking the `rect` method can choose to turn this back on as well.