### PR TITLE
Use the same mask for unwrapping and conncomp regrowing steps

### DIFF
--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -156,7 +156,7 @@ def grow_conncomp_snaphu(
     unw_filename: Filename,
     corr_filename: Filename,
     nlooks: float,
-    mask: Optional[ArrayLike] = None,
+    mask_filename: Optional[Filename] = None,
     ccl_nodata: Optional[int] = DEFAULT_CCL_NODATA,
     cost: str = "smooth",
     min_conncomp_frac: float = 0.0001,
@@ -172,8 +172,8 @@ def grow_conncomp_snaphu(
         Path to input correlation file.
     nlooks : float
         Effective number of looks used to form the input correlation data.
-    mask : Array, optional
-        binary byte mask array, by default None.
+    mask_filename : Filename, optional
+        Path to binary byte mask file, by default None.
         Assumes that 1s are valid pixels and 0s are invalid.
     ccl_nodata : float, optional
         Nodata value for the connected component labels.
@@ -198,17 +198,24 @@ def grow_conncomp_snaphu(
     unw_suffix = full_suffix(unw_filename)
     cc_filename = str(unw_filename).replace(unw_suffix, CONNCOMP_SUFFIX)
 
-    with (
-        snaphu.io.Raster(unw_filename) as unw,
-        snaphu.io.Raster(corr_filename) as corr,
-        snaphu.io.Raster.create(
-            cc_filename,
-            like=unw,
-            nodata=ccl_nodata,
-            dtype="u2",
-            **DEFAULT_TIFF_OPTIONS_RIO,
-        ) as conncomp,
-    ):
+    with ExitStack() as stack:
+        unw = stack.enter_context(snaphu.io.Raster(unw_filename))
+        corr = stack.enter_context(snaphu.io.Raster(corr_filename))
+        conncomp = stack.enter_context(
+            snaphu.io.Raster.create(
+                cc_filename,
+                like=unw,
+                nodata=ccl_nodata,
+                dtype="u2",
+                **DEFAULT_TIFF_OPTIONS_RIO,
+            )
+        )
+
+        if mask_filename is not None:
+            mask = stack.enter_context(snaphu.io.Raster(mask_filename))
+        else:
+            mask = None
+
         snaphu.grow_conncomps(
             unw=unw,
             corr=corr,

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -5,8 +5,6 @@ from contextlib import ExitStack
 from pathlib import Path
 from typing import Optional
 
-from numpy.typing import ArrayLike
-
 from dolphin._types import Filename
 from dolphin.io._core import DEFAULT_TIFF_OPTIONS_RIO
 from dolphin.utils import full_suffix

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -458,15 +458,13 @@ def unwrap(
         )
 
         # Regrow connected components after phase modification
-        corr = io.load_gdal(corr_filename)
-        mask = corr[:] > 0
         # TODO decide whether we want to have the
         # 'min_conncomp_frac' option in the config
         conncomp_path = grow_conncomp_snaphu(
             unw_filename=unw_filename,
             corr_filename=corr_filename,
             nlooks=nlooks,
-            mask=mask,
+            mask_filename=combined_mask_file,
             ccl_nodata=ccl_nodata,
             cost=unwrap_options.snaphu_options.cost,
             scratchdir=scratchdir,


### PR DESCRIPTION


<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Updates the unwrapping code to make sure we pass the same mask to the connected component regrowing step (when applicable) that we passed to the original unwrapper. Previously in the connected component regrowing step, we only masked out pixels with coherence equal to zero.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review
