### PR TITLE
Create `.conncomp` files for `spurt` from temporal coherence

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,7 @@
 build/
 data/
 tests/data/*
+docs/notebooks/input_slcs/*
 dist/
 .nox/
+paper/

--- a/src/dolphin/_overviews.py
+++ b/src/dolphin/_overviews.py
@@ -85,7 +85,7 @@ def create_image_overviews(
     flags = gdal.GA_Update if not external else gdal.GA_ReadOnly
     ds = gdal.Open(fspath(file_path), flags)
     if ds.GetRasterBand(1).GetOverviewCount() > 0:
-        logger.info("%s already has overviews. Skipping.", file_path)
+        logger.debug("%s already has overviews. Skipping.", file_path)
         return
 
     gdal.SetConfigOption("COMPRESS_OVERVIEW", compression)

--- a/src/dolphin/io/_readers.py
+++ b/src/dolphin/io/_readers.py
@@ -712,7 +712,7 @@ class VRTStack(StackReader):
                 )
                 raise FileExistsError(msg)
             else:
-                logger.info(f"Overwriting {outfile}")
+                logger.debug(f"Overwriting {outfile}")
 
         # files: list[Filename] = [Path(f) for f in file_list]
         self._use_abs_path = use_abs_path

--- a/src/dolphin/unwrap/_unwrap_3d.py
+++ b/src/dolphin/unwrap/_unwrap_3d.py
@@ -130,12 +130,9 @@ def _create_conncomps_from_mask(
     # - 0 for invalid, ignored pixels
     # - 1 for the good ones
     # nodata is propagated from `temporal_coherence_file`
-    conncomp_arr1 = arr > temporal_coherence_threshold
-    print(conncomp_arr1.sum())
     conncomp_arr = (
         (arr > temporal_coherence_threshold).astype("uint16").filled(DEFAULT_CCL_NODATA)
     )
-    print((conncomp_arr == 1).sum())
 
     conncomp_files = [
         Path(str(outf).replace(UNW_SUFFIX, CONNCOMP_SUFFIX)) for outf in unw_filenames

--- a/src/dolphin/unwrap/_unwrap_3d.py
+++ b/src/dolphin/unwrap/_unwrap_3d.py
@@ -126,13 +126,15 @@ def _create_conncomps_from_mask(
     temporal_coherence_file: PathOrStr,
     temporal_coherence_threshold: float,
     unw_filenames: Sequence[PathOrStr],
-    dilate_by: int = 21,
+    dilate_by: int = 25,
 ) -> list[Path]:
     arr = io.load_gdal(temporal_coherence_file, masked=True)
     good_pixels = arr > temporal_coherence_threshold
     strel = np.ones((dilate_by, dilate_by))
     # All "1" pixels will be spread out and have (approximately) 1.0 surrounding pixels
     # Threshold back to be a binary image
+    # Note `ndimage.binary_dilation` scales ~quadratically with `dilate_by`, whereas
+    # FFT-based convolution is roughly constant for an `dilate_by`.
     good_pixels_dilated = signal.fftconvolve(good_pixels, strel, mode="same") > 0.95
     # Label the contiguous areas based on the dilated version
     labels, nlabels = ndimage.label(good_pixels_dilated)

--- a/src/dolphin/unwrap/_unwrap_3d.py
+++ b/src/dolphin/unwrap/_unwrap_3d.py
@@ -131,13 +131,13 @@ def _create_conncomps_from_mask(
     arr = io.load_gdal(temporal_coherence_file, masked=True)
     good_pixels = arr > temporal_coherence_threshold
     strel = np.ones((dilate_by, dilate_by))
-    # All "1" pixels will be spread out and have (approximately) 1.0 surrounding pixels
-    # Threshold back to be a binary image
-    # Note `ndimage.binary_dilation` scales ~quadratically with `dilate_by`, whereas
-    # FFT-based convolution is roughly constant for an `dilate_by`.
+    # "1" pixels will be spread out and have (approximately) 1.0 in surrounding pixels
+    # Note: `ndimage.binary_dilation` scales ~quadratically with `dilate_by`,
+    # whereas FFT-based convolution is roughly constant for any `dilate_by`.
     good_pixels_dilated = signal.fftconvolve(good_pixels, strel, mode="same") > 0.95
     # Label the contiguous areas based on the dilated version
     labels, nlabels = ndimage.label(good_pixels_dilated)
+    logger.debug("Labeled %s connected components", nlabels)
     # Now these labels will extend to areas which are not "good" in the original.
     labels[~good_pixels] = 0
     # An make a masked version based on the original nodata, then fill with final output

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -64,7 +64,8 @@ def run(
     if cfg.log_file is None:
         cfg.log_file = cfg.work_directory / "dolphin.log"
     # Set the logging level for all `dolphin.` modules
-    setup_logging(debug=debug, filename=cfg.log_file)
+    for logger_name in ["dolphin", "spurt"]:
+        setup_logging(logger_name=logger_name, debug=debug, filename=cfg.log_file)
     # TODO: need to pass the cfg filename for the logger
     logger.debug(cfg.model_dump())
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

As a stopgap so we don't have a completely different set of output files from one unwrapping method, create connected component labels ~as just a 0/1 mask based on what we pass to `spurt`~:

- Recreate the binary mask that `spurt` uses
- Dilate if by `dilate_by` pixels, by default 25 (or about 750 meters of expansion for 30 m pixels)
- Run `ndimage.label` on the dilated
- Reset the pixels which were 0 to have 0 label

I'm avoiding the snaphu connected component grower because 
1. the different cost function of snaphu may not align with what `spurt` considers good, 
2. the unwrapping errors on an irregular grid seem to manifest differently than what snaphu's errors look like,
3. I believe that if we actually had sparse pixels (which may be good, just disconnected from immediate neighbors), unwrapped them correctly on an irregular grid, then asked snaphu for connected components, the "minimum size" constraint would label them 0

## Related issue number

Closes #347

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review
