### PR TITLE
Add `ignore_errors=True` to `rmtree` for scratch removal

### DIFF
--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -490,6 +490,6 @@ def unwrap(
 
     if delete_scratch:
         assert scratchdir is not None
-        shutil.rmtree(scratchdir)
+        shutil.rmtree(scratchdir, ignore_errors=True)
 
     return Path(unw_filename), conncomp_path


### PR DESCRIPTION
Closes #405
