### PR TITLE
Add `like_filename` for `spurt` connected components

### DIFF
--- a/src/dolphin/unwrap/_unwrap_3d.py
+++ b/src/dolphin/unwrap/_unwrap_3d.py
@@ -152,7 +152,10 @@ def _create_conncomps_from_mask(
     ]
     # Write the first one with geo-metadata
     io.write_arr(
-        arr=conncomp_arr, output_name=conncomp_files[0], nodata=DEFAULT_CCL_NODATA
+        arr=conncomp_arr,
+        like_filename=unw_filenames[0],
+        output_name=conncomp_files[0],
+        nodata=DEFAULT_CCL_NODATA,
     )
     for f in conncomp_files[1:]:
         shutil.copy(conncomp_files[0], f)


### PR DESCRIPTION
The connected component labels are missing geo-metadata.