### PR TITLE
Adjust `GDAL_MAX_DATASET_POOL_SIZE` if system file limit is low

### DIFF
--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -124,6 +124,9 @@ def run(
     in both ascending and descending tracks imply uplift).
 
     """
+    # Ensure we wont run into problems with large gdal reads from deep VRTs.
+    utils.check_open_file_limit()
+
     Path(output_dir).mkdir(exist_ok=True, parents=True)
 
     condition_func = argmax_index if condition == CallFunc.MAX else argmin_index

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -63,11 +63,14 @@ def run(
     """
     if cfg.log_file is None:
         cfg.log_file = cfg.work_directory / "dolphin.log"
+
     # Set the logging level for all `dolphin.` modules
     for logger_name in ["dolphin", "spurt"]:
         setup_logging(logger_name=logger_name, debug=debug, filename=cfg.log_file)
-    # TODO: need to pass the cfg filename for the logger
+
     logger.debug(cfg.model_dump())
+    # Ensure we wont run into problems with large gdal reads from VRTs.
+    utils.check_open_file_limit()
 
     if not cfg.worker_settings.gpu_enabled:
         utils.disable_gpu()


### PR DESCRIPTION
If the system limit for open file descriptors is low, reading from a VRT larger than this limit will always throw `OSError: [Errno 24] Too many open files`. Lowering the `GDAL_MAX_DATASET_POOL_SIZE` variable keeps GDAL from having all the files open at once (e.g. if you are inverting for ~1000 interferograms and using a VRT to read them).