### PR TITLE
Fix ionosphereic date parsing and grouping

### DIFF
--- a/src/dolphin/workflows/_utils.py
+++ b/src/dolphin/workflows/_utils.py
@@ -50,7 +50,7 @@ def parse_ionosphere_files(
     ionosphere_files : Sequence[Union[str, Path]]
         List of ionosphere file paths.
     iono_date_fmts: Sequence[str]
-        Format of deates within ionosphere file names to search for.
+        Format of dates within ionosphere file names to search for.
         Default is ["%j0.%y", "%Y%j0000"], which matches the old name
         'jplg2970.16i', and the new name format
         'JPL0OPSFIN_20232540000_01D_02H_GIM.INX' (respectively)

--- a/src/dolphin/workflows/_utils.py
+++ b/src/dolphin/workflows/_utils.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
 import contextlib
+import datetime
 import logging
+from collections import defaultdict
 from pathlib import Path
+from typing import Mapping, Sequence
+
+from opera_utils import group_by_date
+
+from dolphin._types import Filename
 
 from .config import DisplacementWorkflow
 
@@ -30,3 +37,38 @@ def _create_burst_cfg(
 def _remove_dir_if_empty(d: Path) -> None:
     with contextlib.suppress(OSError):
         d.rmdir()
+
+
+def parse_ionosphere_files(
+    ionosphere_files: Sequence[Filename],
+    iono_date_fmts: Sequence[str] = ["%j0.%y", "%Y%j0000"],
+) -> Mapping[tuple[datetime.datetime], list[Path]]:
+    """Parse ionosphere files and group them by date.
+
+    Parameters
+    ----------
+    ionosphere_files : Sequence[Union[str, Path]]
+        List of ionosphere file paths.
+    iono_date_fmts: Sequence[str]
+        Format of deates within ionosphere file names to search for.
+        Default is ["%j0.%y", "%Y%j0000"], which matches the old name
+        'jplg2970.16i', and the new name format
+        'JPL0OPSFIN_20232540000_01D_02H_GIM.INX' (respectively)
+
+
+    Returns
+    -------
+    grouped_iono_files : Mapping[Tuple[datetime], List[Path]]
+        Dictionary mapping dates to lists of files.
+
+    """
+    grouped_iono_files: Mapping[tuple[datetime.datetime], list[Path]] = defaultdict(
+        list
+    )
+    for fmt in iono_date_fmts:
+        group_iono = group_by_date(ionosphere_files, file_date_fmt=fmt)
+        if () in group_iono:  # files which didn't match the date format
+            group_iono.pop(())
+        grouped_iono_files = {**grouped_iono_files, **group_iono}
+
+    return grouped_iono_files


### PR DESCRIPTION
Bug found by @collinss-jpl : What was happning was
- the `group_by_date` function will run through all files given and, if no date is matched, puts these files with the `()` key
- this key is overwritten in the second ionosphere format iteration.

This adds a test for the failing case (with just a subset of the old filenames), and moves the parsing to a separate function to test.