### PR TITLE
Fix handling of `nodata` during timeseries conversion to meters

### DIFF
--- a/tests/test_workflows_displacement.py
+++ b/tests/test_workflows_displacement.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from opera_utils import group_by_burst
 
-from dolphin.io import get_raster_units
+from dolphin.io import get_raster_nodata, get_raster_units
 from dolphin.utils import flatten, full_suffix
 from dolphin.workflows import config, displacement
 
@@ -50,6 +50,12 @@ def test_displacement_run_single(opera_slc_files: list[Path], tmpdir):
 
         # check the network size
         assert len(paths.unwrapped_paths) > len(paths.timeseries_paths)
+
+        # Check nodata values
+        assert get_raster_nodata(paths.unwrapped_paths[0]) is not None
+        assert get_raster_nodata(paths.unwrapped_paths[0]) == get_raster_nodata(
+            paths.timeseries_paths[0]
+        )
 
 
 def test_displacement_run_single_official_opera_naming(


### PR DESCRIPTION
After re-referencing, the nodata values at the boundaries are turned into random numbers. This now uses masked arrays which can retain the mask during shifting/scaling.


In a small test, the unwrapped interferograms have ~93% valid data:
```
$ gdalinfo -stats unwrapped/20180210_20180222.unw.tif | tail -1
    STATISTICS_VALID_PERCENT=93
```
but the timeseries rasters have ~all "valid data":
```
$ gdalinfo -stats timeseries/20180210_20180222.tif | tail -1
    STATISTICS_VALID_PERCENT=99.999
```


after this PR, this is fixed:
```
$ gdalinfo -stats timeseries/20180210_20180222.tif | tail -1
    STATISTICS_VALID_PERCENT=93
```