### PR TITLE
Change `is_single_reference` to only look for number of interferograms

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
-# mkdocs requirements
-markdown # for mdx_bib
+markdown
 mkdocs
 mkdocs-gen-files
 mkdocs-jupyter
@@ -7,5 +6,5 @@ mkdocs-literate-nav
 mkdocs-material
 mkdocs-section-index
 mkdocstrings[python]
-pybtex # for mdx_bib
+pybtex
 pymdown-extensions

--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -142,9 +142,11 @@ def run(
     sar_dates = sorted(set(utils.flatten(ifg_date_pairs)))
     # if we did single-reference interferograms, for `n` sar dates, we will only have
     # `n-1` interferograms. Any more than n-1 ifgs means we need to invert
-    is_single_reference = (len(unwrapped_paths) == len(sar_dates) - 1) and all(
-        pair[0] == ifg_date_pairs[0][0] for pair in ifg_date_pairs
-    )
+    is_single_reference = len(unwrapped_paths) == len(sar_dates) - 1
+    # TODO: Do we ever want to invert this case: the "trivial" network,
+    # which has 1 ifg per date difference, but a moving reference date?
+    # The extra condition to check is
+    # ... and all(pair[0] == ifg_date_pairs[0][0] for pair in ifg_date_pairs)
 
     # check if we even need to invert, or if it was single reference
     inverted_phase_paths: list[Path] = []

--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -129,6 +129,7 @@ def run(
 
     condition_func = argmax_index if condition == CallFunc.MAX else argmin_index
     if reference_point == (-1, -1):
+        logger.info("Selecting a reference point for unwrapped interferograms")
         ref_point = select_reference_point(
             condition_file=condition_file,
             output_dir=Path(output_dir),
@@ -162,8 +163,6 @@ def run(
             wavelength=wavelength,
         )
     else:
-        logger.info("Selecting a reference point for unwrapped interferograms")
-
         logger.info("Inverting network of %s unwrapped ifgs", len(unwrapped_paths))
         inverted_phase_paths = invert_unw_network(
             unw_file_list=unwrapped_paths,

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -394,6 +394,10 @@ def create_ifgs(
     written_ifgs = set(ifg_dir.glob("*.int*"))
     for p in written_ifgs - requested_ifgs:
         p.unlink()
+
+    if len(set(get_dates(ifg_file_list[0]))) == 1:
+        same_date_ifg = ifg_file_list.pop(0)
+        same_date_ifg.unlink()
     return ifg_file_list
 
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,7 +7,7 @@ pooch
 pre-commit
 pytest
 pytest-cov
-pytest-randomly # control random seed
-pytest-xdist # parallel tests: https://pytest-xdist.readthedocs.io/en/latest/
+pytest-randomly
+pytest-xdist
 shapely
-xarray # For dolphin.atmosphere tests
+xarray

--- a/tests/test_workflows_displacement.py
+++ b/tests/test_workflows_displacement.py
@@ -208,7 +208,7 @@ def test_displacement_run_extra_reference_date(opera_slc_files: list[Path], tmpd
             # The "base phase" should be 20220103
             assert slc_paths[0].name == "compressed_20220103_20220102_20220104.tif"
 
-        # The unwrappd files should have a changeover to the new reference
+        # The unwrapped/timeseries files should have a changeover to the new reference
         assert paths.unwrapped_paths is not None
         unw_names = [pp.name for pp in paths.unwrapped_paths]
         assert unw_names == [
@@ -216,12 +216,10 @@ def test_displacement_run_extra_reference_date(opera_slc_files: list[Path], tmpd
             "20220101_20220103.unw.tif",
             "20220103_20220104.unw.tif",
         ]
-
-        # But the timeseries will have inverted the results
         assert paths.timeseries_paths is not None
         ts_names = [pp.name for pp in paths.timeseries_paths]
         assert ts_names == [
             "20220101_20220102.tif",
             "20220101_20220103.tif",
-            "20220101_20220104.tif",
+            "20220103_20220104.tif",
         ]


### PR DESCRIPTION
Currently we would run the inversion for unwrapped outputs like `1_2, 1_3, 3_4, 3_5` to make `1_2, 1_3, 1_4, 1_5`.  Since this is not an output that normal use cases would run into, this reverts the check to simply look at the number of interferograms. 
Now those unwrapped outputs would just be moved into the `timeseries/` folder, but get shifted by the reference point, and converted to meters.