### PR TITLE
Use `dataclasses` instead of `NamedTuple` for displacement, stitched outputs

### DIFF
--- a/src/dolphin/unwrap/_post_process.py
+++ b/src/dolphin/unwrap/_post_process.py
@@ -69,7 +69,7 @@ def get_2pi_ambiguities(
 
 
 def interpolate_masked_gaps(
-    unw: NDArray[np.float_], ifg: NDArray[np.complex64]
+    unw: NDArray[np.float64], ifg: NDArray[np.complex64]
 ) -> None:
     """Perform phase unwrapping using nearest neighbor interpolation of ambiguities.
 

--- a/src/dolphin/unwrap/_unwrap_3d.py
+++ b/src/dolphin/unwrap/_unwrap_3d.py
@@ -210,7 +210,7 @@ def filled_masked_unw_regions(
 
 def _reform_wrapped_phase(
     unw_filename: PathOrStr, ifg_filenames: Sequence[PathOrStr]
-) -> tuple[NDArray[np.float_], NDArray[np.complex64]]:
+) -> tuple[NDArray[np.float64], NDArray[np.complex64]]:
     """Load unwrapped phase, and re-calculate the corresponding wrapped phase.
 
     Finds the matching ifg to `unw_filename`, or uses 2 to compute the correct

--- a/src/dolphin/workflows/stitching_bursts.py
+++ b/src/dolphin/workflows/stitching_bursts.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
-from typing import NamedTuple, Sequence
+from typing import Sequence
 
 from dolphin import stitching
 from dolphin._log import log_runtime
@@ -18,22 +19,23 @@ from .config import OutputOptions
 logger = logging.getLogger(__name__)
 
 
-class StitchedOutputs(NamedTuple):
+@dataclass
+class StitchedOutputs:
     """Output rasters from stitching step."""
 
-    stitched_ifg_paths: list[Path]
+    ifg_paths: list[Path]
     """List of Paths to the stitched interferograms."""
     interferometric_corr_paths: list[Path]
     """List of Paths to interferometric correlation files created."""
-    stitched_temp_coh_file: Path
+    temp_coh_file: Path
     """Path to temporal correlation file created."""
-    stitched_ps_file: Path
+    ps_file: Path
     """Path to ps mask file created."""
-    stitched_amp_disp_file: Path
+    amp_dispersion_file: Path
     """Path to amplitude dispersion file created."""
-    stitched_shp_count_file: Path
+    shp_count_file: Path
     """Path to SHP count file created."""
-    stitched_similarity_file: Path
+    similarity_file: Path
     """Path to cosine similarity file created."""
 
 


### PR DESCRIPTION
Allows adjusting it after the fact by `disp-s1`. Removed the unpacking of 7 files in favor of using the attribute names to refer to the paths.