### PR TITLE
Add `outside_input_range` options to `get_nearest_date_idx`

### DIFF
--- a/src/dolphin/unwrap/_unwrap_3d.py
+++ b/src/dolphin/unwrap/_unwrap_3d.py
@@ -45,6 +45,11 @@ def unwrap_spurt(
         unwrap_tiles,
     )
 
+    if existing_unw_files := sorted(Path(output_path).glob(f"*{UNW_SUFFIX}")):
+        logger.info(f"Found {len(existing_unw_files)} unwrapped files")
+        existing_ccl_files = sorted(Path(output_path).glob(f"*{CONNCOMP_SUFFIX}"))
+        return existing_unw_files, existing_ccl_files
+
     if cor_filenames is not None:
         assert len(ifg_filenames) == len(cor_filenames)
     if mask_filename is not None:

--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -11,7 +11,7 @@ from concurrent.futures import Executor, Future
 from itertools import chain
 from multiprocessing import cpu_count
 from pathlib import Path
-from typing import Any, Iterable, Optional, Sequence, Union
+from typing import Any, Iterable, Literal, Optional, Sequence, Union
 
 import numpy as np
 from numpy.typing import ArrayLike, DTypeLike
@@ -695,13 +695,19 @@ class DummyProcessPoolExecutor(Executor):
 def get_nearest_date_idx(
     input_items: Sequence[datetime.datetime],
     requested: datetime.datetime,
+    outside_input_range: Literal["allow", "warn", "raise"] = "warn",
 ) -> int:
     """Find the index nearest to `requested` within `input_items`."""
     sorted_inputs = sorted(input_items)
     if not sorted_inputs[0] <= requested <= sorted_inputs[-1]:
         msg = f"Requested {requested} falls outside of input range: "
         msg += f"{sorted_inputs[0]}, {sorted_inputs[-1]}"
-        raise ValueError(msg)
+        if outside_input_range == "raise":
+            raise ValueError(msg)
+        elif outside_input_range == "warn":
+            warnings.warn(msg, stacklevel=2)
+        else:
+            pass
 
     nearest_idx = min(
         range(len(input_items)),

--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -695,7 +695,7 @@ class DummyProcessPoolExecutor(Executor):
 def get_nearest_date_idx(
     input_items: Sequence[datetime.datetime],
     requested: datetime.datetime,
-    outside_input_range: Literal["allow", "warn", "raise"] = "warn",
+    outside_input_range: Literal["allow", "warn", "raise"] = "raise",
 ) -> int:
     """Find the index nearest to `requested` within `input_items`."""
     sorted_inputs = sorted(input_items)


### PR DESCRIPTION
This lets us skip/warn if needed for `get_nearest_idx`.