### PR TITLE
Pass through `units` during `timeseries._redo_reference`

### DIFF
--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -185,7 +185,7 @@ def run(
 
     if add_overviews:
         logger.info("Creating overviews for timeseries images")
-        create_overviews(inverted_phase_paths, image_type=ImageType.UNWRAPPED)
+        create_overviews(final_ts_paths, image_type=ImageType.UNWRAPPED)
 
     if run_velocity:
         logger.info("Estimating phase velocity")
@@ -197,7 +197,7 @@ def run(
             cor_file_list = None
         else:
             cor_file_list = (
-                corr_paths if len(corr_paths) == len(inverted_phase_paths) else None
+                corr_paths if len(corr_paths) == len(final_ts_paths) else None
             )
 
         if velocity_file is None:

--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -161,7 +161,7 @@ def run(
             "Skipping inversion step: only single reference interferograms exist."
         )
         # Copy over the unwrapped paths to `timeseries/`
-        final_out = _convert_and_reference(
+        final_ts_paths = _convert_and_reference(
             unwrapped_paths,
             output_dir=output_dir,
             reference_point=ref_point,
@@ -179,9 +179,9 @@ def run(
             method=method,
         )
         if extra_reference_date is None:
-            final_out = inverted_phase_paths
+            final_ts_paths = inverted_phase_paths
         else:
-            final_out = _redo_reference(inverted_phase_paths, extra_reference_date)
+            final_ts_paths = _redo_reference(inverted_phase_paths, extra_reference_date)
 
     if add_overviews:
         logger.info("Creating overviews for timeseries images")
@@ -204,7 +204,7 @@ def run(
             velocity_file = Path(output_dir) / "velocity.tif"
 
         create_velocity(
-            unw_file_list=inverted_phase_paths,
+            unw_file_list=final_ts_paths,
             output_file=velocity_file,
             reference=ref_point,
             cor_file_list=cor_file_list,
@@ -213,7 +213,7 @@ def run(
             num_threads=num_threads,
         )
 
-    return final_out, ref_point
+    return final_ts_paths, ref_point
 
 
 def _redo_reference(

--- a/tests/test_workflows_displacement.py
+++ b/tests/test_workflows_displacement.py
@@ -225,6 +225,7 @@ def test_displacement_run_extra_reference_date(
             "20220101_20220103.tif",
             "20220103_20220104.tif",
         ]
+        assert all(get_raster_units(p) == "meters" for p in paths.timeseries_paths)
 
         unw_names = [pp.name for pp in paths.unwrapped_paths]
         if cfg.unwrap_options.unwrap_method == "spurt":
@@ -242,3 +243,5 @@ def test_displacement_run_extra_reference_date(
                 "20220101_20220103.unw.tif",
                 "20220103_20220104.unw.tif",
             ]
+
+        assert all(get_raster_units(p) == "radians" for p in paths.unwrapped_paths)


### PR DESCRIPTION
By not including `units = ...`, everything after the reference change lost the `meters` from unwrapping

```
$ rio info scratch/timeseries/20180722_20190711.tif | jq .units
[
  "meters"
]

$ rio info scratch/timeseries/20190711_20190717.tif | jq .units
[
  null
]
```