### PR TITLE
Fix the relative index used to make compressed SLCs

### DIFF
--- a/src/dolphin/workflows/single.py
+++ b/src/dolphin/workflows/single.py
@@ -236,12 +236,16 @@ def run_wrapped_phase_single(
         # Get the mean to set as pixel magnitudes
         abs_stack = np.abs(cur_data[first_real_slc_idx:, in_trim_rows, in_trim_cols])
         cur_data_mean, cur_amp_dispersion, _ = calc_ps_block(abs_stack)
+        # NOTE: the `ministack.compressed_reference_idx` was set relative to *all*
+        # input images, real and compressed.
+        # Since we pass in just the first real idx, we have to subtract that off
+        ref_index_relative = ministack.compressed_reference_idx - first_real_slc_idx
         cur_comp_slc = compress(
             # Get the inner portion of the full-res SLC data
             cur_data[first_real_slc_idx:, in_trim_rows, in_trim_cols],
             pl_output.cpx_phase[first_real_slc_idx:, out_trim_rows, out_trim_cols],
             slc_mean=cur_data_mean,
-            reference_idx=ministack.compressed_reference_idx,
+            reference_idx=ref_index_relative,
         )
         # TODO: truncate
 

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -142,7 +142,7 @@ def run(
     extra_reference_date = cfg.output_options.extra_reference_date
     if extra_reference_date:
         new_compressed_slc_reference_idx = get_nearest_date_idx(
-            [dtup[0] for dtup in input_dates], extra_reference_date
+            [date_tup[0] for date_tup in input_dates], extra_reference_date
         )
     else:
         new_compressed_slc_reference_idx = None


### PR DESCRIPTION
Discovered this after repeated batch runs of `disp-s1`, manually passing in stacks with compressed SLCs:

```python-traceback
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/workflows/wrapped_phase.py", line 171, in run
    ) = sequential.run_wrapped_phase_sequential(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/workflows/sequential.py", line 114, in run_wrapped_phase_sequential
    run_wrapped_phase_single(
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/_decorators.py", line 106, in wrapper
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/workflows/single.py", line 239, in run_wrapped_phase_single
    cur_comp_slc = compress(
                   ^^^^^^^^^
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/phase_link/_compress.py", line 39, in compress
    pl_referenced = pl_cpx_phase * pl_cpx_phase[reference_idx][None, :, :].conj()
                                   ~~~~~~~~~~~~^^^^^^^^^^^^^^^
IndexError: index 17 is out of bounds for axis 0 with size 15
```
The "extra_reference_index" asked for image index 17; there were 15 real, 5 compressed. 

This fixes the `phase_link.compress` call to adjust for the real SLC offset.

Verified this worked by checking `OPERA_CSLC * compressed_slc.conj()` for the corresponding dates:

<img width="335" alt="image" src="https://github.com/user-attachments/assets/7bc916aa-ca61-49d1-bc18-2e7337c7a1d9">
