### PR TITLE
Fix `in_trim_slice` size for non overlapping blocks

### DIFF
--- a/src/dolphin/io/_blocks.py
+++ b/src/dolphin/io/_blocks.py
@@ -146,12 +146,11 @@ def get_full_res_trim(
 ) -> BlockIndices:
     in_no_pad_rows, in_no_pad_cols = in_no_pad_block
     in_rows, in_cols = in_block
-    trim_full_col = slice(
-        in_no_pad_cols.start - in_cols.start, in_no_pad_cols.stop - in_cols.stop
-    )
-    trim_full_row = slice(
-        in_no_pad_rows.start - in_rows.start, in_no_pad_rows.stop - in_rows.stop
-    )
+    # If the stops are the same, return None instead of slice(0, 0)
+    col_stop = (in_no_pad_cols.stop - in_cols.stop) or None
+    row_stop = (in_no_pad_rows.stop - in_rows.stop) or None
+    trim_full_col = slice(in_no_pad_cols.start - in_cols.start, col_stop)
+    trim_full_row = slice(in_no_pad_rows.start - in_rows.start, row_stop)
     return BlockIndices.from_slices(trim_full_row, trim_full_col)
 
 

--- a/tests/test_io_blocks.py
+++ b/tests/test_io_blocks.py
@@ -147,6 +147,14 @@ class TestBlockManager:
             assert row_slice.stop < nrows - out_row_margin
             assert col_slice.stop < ncols - out_col_margin
 
+    def test_zero_trim_size(self):
+        bm = StridedBlockManager(
+            (7, 7), (100, 100), Strides(3, 3), half_window=HalfWindow(1, 1)
+        )
+        in_row_trim, in_col_trim = next(iter(bm.iter_blocks()))[-1]
+        assert get_slice_length(in_row_trim, data_size=7) == 7
+        assert get_slice_length(in_col_trim, data_size=7) == 7
+
 
 # @pytest.mark.skip(reason="Uses old logic ")
 class TestFakeProcess:


### PR DESCRIPTION
Having a `HalfWindow(1, 1)` and `Strides(3, 3)` should lead to non overlapping blocks. The output trimming slices were working, but input (full res) slices were `slice(0, 0)` instead of `slice(0, None)`