### PR TITLE
Call spurt from `subprocess` to avoid fork issues

### DIFF
--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -117,7 +117,7 @@ def run(
             ifg_filenames=ifg_filenames,
             output_path=output_path,
             temporal_coherence_file=temporal_coherence_file,
-            cor_filenames=cor_filenames,
+            # cor_filenames=cor_filenames,
             mask_filename=mask_filename,
             options=unwrap_options.spurt_options,
             scratchdir=scratchdir,

--- a/src/dolphin/unwrap/_unwrap_3d.py
+++ b/src/dolphin/unwrap/_unwrap_3d.py
@@ -47,7 +47,8 @@ def unwrap_spurt(
     # We name it "temporal_coherence.tif" so spurt reads it.
     # Also make it float32 as though it were temp coh
     scratch_path = Path(scratchdir) if scratchdir else Path(output_path) / "scratch"
-    combined_mask_filename = Path(scratch_path) / "temporal_coherence.tif"
+    scratch_path.mkdir(exist_ok=True, parents=True)
+    combined_mask_filename = scratch_path / "temporal_coherence.tif"
     io.write_arr(
         arr=combined_mask.astype("float32"), output_name=combined_mask_filename
     )


### PR DESCRIPTION
Memory usage seems to be much higher when using `spawn` instead of `fork`, possibly due to passing in the Delaunay object.
Havent gotten to really debug that problem yet. [fil](https://pythonspeed.com/fil) seems like a good option to try later.