### PR TITLE
Use `output_reference_idx` as the default for creating compressed slcs with `ALWAYS_FIRST`

### DIFF
--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -468,7 +468,9 @@ class MiniStackPlanner(BaseStack):
             elif self.compressed_slc_plan == CompressedSlcPlan.ALWAYS_FIRST:
                 # Simplest operational version: CompSLCs have same base phase,
                 # but different "residual" added on
-                compressed_reference_idx = 0
+                # We use the `output_reference_idx`, 0 by default, but this index
+                # may be passed in if we are manually specifying an output
+                compressed_reference_idx = self.output_reference_idx
             elif self.compressed_slc_plan == CompressedSlcPlan.FIRST_PER_MINISTACK:
                 # Like Ansari, 2017 paper: each ministack is "self contained"
                 compressed_reference_idx = num_ccslc


### PR DESCRIPTION
Sara found the problem with repeatedly running disp-s1 with a reference update:

```
ministack 0:
compressed_t042_088905_iw1_20160810_20160810_20170407.h5 
ministack1:
compressed_t042_088905_iw1_20170817_20170419_20171028.h5 
ministack2:
compressed_t042_088905_iw1_20160810_20171109_20180508.tif
```

Even though in Run2 we are making interferograms relative to 20170817, the `compressed_reference_idx` snapped back to 0.