### PR TITLE
Increase the `buffer_pixels` when making OPERA CSLC mask

### DIFF
--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -476,7 +476,7 @@ def _get_mask(
         make_nodata_mask(
             opera_file_list=cslc_file_list,
             out_file=nodata_mask_file,
-            buffer_pixels=200,
+            buffer_pixels=800,
         )
         mask_files.append(nodata_mask_file)
     except Exception as e:


### PR DESCRIPTION
Due to the geolocation errors, sometimes 200 pixels is not quite enough. 800 pixels on each edge seems conservative

Subsampled by (3, 6) for the rows, cols:
<img width="762" alt="image" src="https://github.com/user-attachments/assets/b9387a98-2ebf-48d4-8b03-d45250f861eb">


<img width="783" alt="image" src="https://github.com/user-attachments/assets/c17b9ece-16e7-4b49-92a0-37de7077ce47">

The block was skipped because the 200 pixel buffer on ESA's bounding box wasn't sufficient
<img width="781" alt="image" src="https://github.com/user-attachments/assets/a54e4682-4e28-4e9b-92b5-e0e32f4eec81">
