### PR TITLE
Add a retry to spurt for brokenprocesspools

### DIFF
--- a/src/dolphin/unwrap/_unwrap_3d.py
+++ b/src/dolphin/unwrap/_unwrap_3d.py
@@ -126,6 +126,7 @@ def unwrap_spurt(
                 logging.info(f"Command succeeded on attempt {attempt + 1}")
             except subprocess.CalledProcessError as e:
                 logging.warning(f"Attempt {attempt + 1} failed: {e}")
+                logging.exception(f"Error output:\n{e.stderr}")
             else:
                 return result
 


### PR DESCRIPTION
`spurt` running on AWS was hitting weird `BrokenProcessPool` errors. Difficult to debug due to AWS opaqueness. Rerunning may help, since spurt has the JSON and hdf5 tile checkpoint files.