### PR TITLE
Avoid capturing all logging from spurt

### DIFF
--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -392,7 +392,7 @@ def censored_lstsq(A, B, M):
     """
     # if B is a vector, simply drop out corresponding rows in A
     if B.ndim == 1 or B.shape[1] == 1:
-        return jnp.linalg.leastsq(A[M], B[M])[0]
+        return jnp.linalg.lstsq(A[M], B[M])[0]
 
     # else solve via tensor representation
     rhs = jnp.dot(A.T, M * B).T[:, :, None]  # k x n x 1 tensor
@@ -420,7 +420,7 @@ def weighted_lstsq_single(
 
     Parameters
     ----------
-    A : Arraylike
+    A : ArrayLike
         Incidence matrix of shape (n_ifgs, n_sar_dates - 1)
     b : ArrayLike, 1D
         The phase differences between the ifg pairs
@@ -1051,8 +1051,8 @@ def invert_unw_network(
 def correlation_to_variance(correlation: ArrayLike, nlooks: int) -> Array:
     r"""Convert interferometric correlation to phase variance.
 
-    Uses the CRLB formula from Rodriguez, 1992 [1]_ to get the phase variance,
-    \sigma_{\phi}^2:
+    Uses the Cramer-Rao Lower Bound (CRLB) formula from Rodriguez, 1992 [1]_ to
+    get the phase variance, \sigma_{\phi}^2:
 
     \[
         \sigma_{\phi}^{2} = \frac{1}{2N_{L}} \frac{1 - \gamma^{2}}{\gamma^{2}}
@@ -1195,14 +1195,14 @@ def _get_largest_conncomp_mask(
     conncomp_intersection = io.load_gdal(conncomp_intersection_file, masked=True)
 
     # Find the largest conncomp region in the intersection
-    label, nlabels = ndimage.label(
+    label, n_labels = ndimage.label(
         conncomp_intersection.filled(0), structure=np.ones((3, 3))
     )
-    if nlabels == 0:
+    if n_labels == 0:
         raise ReferencePointError(
             "Connected components intersection left no valid regions"
         )
-    logger.info("Found %d connected components in intersection", nlabels)
+    logger.info("Found %d connected components in intersection", n_labels)
 
     # Make a mask of the largest conncomp:
     # Find the label with the most pixels using bincount

--- a/src/dolphin/unwrap/_post_process.py
+++ b/src/dolphin/unwrap/_post_process.py
@@ -75,7 +75,7 @@ def interpolate_masked_gaps(
 
     Overwrites `unw`'s masked pixels with the interpolated values.
 
-    This function takes an input unwrapped phase array containin NaNs at masked pixel.
+    This function takes an input unwrapped phase array containing NaNs at masked pixel.
     It calculates the phase ambiguity, K, at the attempted unwrapped pixels, then
     interpolates the ambiguities to fill the gaps.
     The masked pixels get the value of the original wrapped phase + 2pi*K.

--- a/src/dolphin/unwrap/_unwrap_3d.py
+++ b/src/dolphin/unwrap/_unwrap_3d.py
@@ -65,7 +65,8 @@ def unwrap_spurt(
     # expected in the one directory
     for fn in ifg_filenames:
         new_path = scratch_path / Path(fn).name
-        new_path.symlink_to(fn)
+        if not new_path.exists():
+            new_path.symlink_to(fn)
 
     cmd = [
         "python",
@@ -122,7 +123,7 @@ def unwrap_spurt(
     def run_with_retry(cmd: list[str], num_retries: int = 3):
         for attempt in range(num_retries):
             try:
-                result = subprocess.run(cmd, check=True, text=True, capture_output=True)
+                result = subprocess.run(cmd, check=True, text=True)
                 logging.info(f"Command succeeded on attempt {attempt + 1}")
             except subprocess.CalledProcessError as e:
                 logging.warning(f"Attempt {attempt + 1} failed: {e}")


### PR DESCRIPTION
This should print the logging to the terminal to see the progress.

Symlink check is to avoid `FileExistsError` after a restart for the line `new_path.symlink_to(fn)`