### PR TITLE
Use `nearest` sampling to stitch static layers

### DIFF
--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -589,6 +589,7 @@ def prepare_geometry(
                 out_nodata=nodata,
                 target_aligned_pixels=True,
                 strides=strides,
+                resample_alg="nearest",
                 overwrite=False,
                 options=options,
             )


### PR DESCRIPTION
Using `lanczos` resampling here may be been accidental, or may have been changed in `merge_images` after it was created. 
Currently on disp-s1 frame 8882, we see this for the `los_east` 30 meter dataset

<img width="504" alt="image" src="https://github.com/user-attachments/assets/a1c07047-de27-49d4-8e29-821159450e8b">

<img width="456" alt="image" src="https://github.com/user-attachments/assets/ac516737-e709-40b6-8028-c8a3c0db8c5b">

with nearest
<img width="518" alt="image" src="https://github.com/user-attachments/assets/703ffa8e-54ea-4ca6-956f-4d37e1c27b2b">

(colorbar is different from a lack of spurrious 0.01 values)

