### PR TITLE
Speed up the post-`spurt` 2-pi ambiguity interpolation

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -16,7 +16,7 @@ dependencies:
   - pyproj>=3.3
   - rasterio>=1.3
   - ruamel.yaml>=0.15
-  - scipy>=1.9 # "scipy 0.16+ is required for linear algebra", numba. 1.9 is the oldest version working with jax=0.4.19
+  - scipy>=1.12 # "scipy 0.16+ is required for linear algebra", numba. 1.9 is the oldest version working with jax=0.4.19
   - threadpoolctl>=3.0
   - tqdm>=4.60
   - typing_extensions>=3.10

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -6,6 +6,8 @@ dependencies:
   - pip>=21.3  # https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#editable-installation
   - git  # for pip install, due to setuptools_scm
   - gdal>=3.3
+  - libgdal-netcdf
+  - libgdal-hdf5
   - h5py>=3.6
   - hdf5!=1.12.2 # https://github.com/SciTools/iris/issues/5187 and https://github.com/pydata/xarray/issues/7549
   - jax>=0.4.19

--- a/src/dolphin/unwrap/_post_process.py
+++ b/src/dolphin/unwrap/_post_process.py
@@ -129,13 +129,14 @@ def interpolate_masked_gaps(
 
     unw[interpolate_mask] = np.angle(ifg[interpolate_mask]) + (
         TWOPI
-        * np.round(resize(interpolated_sub, ifg.shape)).astype(int)[interpolate_mask]
+        * np.round(_resize(interpolated_sub, ifg.shape)).astype(int)[interpolate_mask]
     )
 
 
-def resize(image: ArrayLike, output_shape_2d: tuple[int, int]):
+def _resize(image: ArrayLike, output_shape: tuple[int, int]):
+    """Resize `image` to be the same shape as `output_shape`."""
     input_shape = image.shape[-2:]
-    factors = np.divide(input_shape, output_shape_2d)
+    factors = np.divide(input_shape, output_shape)
 
     # Translate modes used by np.pad to those used by scipy.ndimage
     zoom_factors = [1 / f for f in factors]

--- a/src/dolphin/unwrap/_unwrap_3d.py
+++ b/src/dolphin/unwrap/_unwrap_3d.py
@@ -155,7 +155,9 @@ def unwrap_spurt(
         options.temporal_coherence_threshold,
         unw_filenames=unw_filenames,
     )
-    filled_masked_unw_regions(unw_filenames, ifg_filenames)
+
+    if options.run_ambiguity_interpolation:
+        filled_masked_unw_regions(unw_filenames, ifg_filenames)
     return unw_filenames, conncomp_filenames
 
 

--- a/src/dolphin/workflows/config/_unwrap_options.py
+++ b/src/dolphin/workflows/config/_unwrap_options.py
@@ -266,6 +266,13 @@ class SpurtOptions(BaseModel, extra="forbid"):
         ge=0.0,
         lt=1.0,
     )
+    run_ambiguity_interpolation: bool = Field(
+        True,
+        description=(
+            "After running spurt, interpolate the values that were masked during"
+            " unwrapping (which are otherwise left as nan)."
+        ),
+    )
     # TODO: do we want to allow a "AND" or "OR" option, so users can pick if they want
     # `good_sim & good_temp_coh`, or `good_sim | good_temp_coh`
     general_settings: SpurtGeneralSettings = Field(default_factory=SpurtGeneralSettings)


### PR DESCRIPTION
Main branch currently takes ~50 seconds for an interferogram; this PR is taking around 13 seconds.

Also adding the flag to turn this off entirely; future work could be to give some other guess within spurt instead of this workaround.