### PR TITLE
Use `fspath` when opening with `gdal` to support older versions

### DIFF
--- a/src/dolphin/io/_core.py
+++ b/src/dolphin/io/_core.py
@@ -86,7 +86,7 @@ DEFAULT_HDF5_OPTIONS = {
 def _get_gdal_ds(filename: Filename) -> gdal.Dataset:
     if str(filename).startswith("s3://"):
         return gdal.Open(S3Path(str(filename)).to_gdal())
-    return gdal.Open(filename)
+    return gdal.Open(fspath(filename))
 
 
 def load_gdal(


### PR DESCRIPTION
Fixes #501 