### PR TITLE
'Use `nearest` resampling for merging temporal coherence

### DIFF
--- a/src/dolphin/workflows/stitching_bursts.py
+++ b/src/dolphin/workflows/stitching_bursts.py
@@ -132,6 +132,7 @@ def run(
             temp_coh_file_list,
             outfile=stitched_temp_coh_file,
             driver="GTiff",
+            resample_alg="nearest",
             out_bounds=out_bounds,
             out_bounds_epsg=output_options.bounds_epsg,
         )
@@ -157,28 +158,33 @@ def run(
             amp_dispersion_list,
             outfile=stitched_amp_disp_file,
             driver="GTiff",
+            resample_alg="nearest",
             out_bounds=out_bounds,
             out_bounds_epsg=output_options.bounds_epsg,
         )
         repack_raster(stitched_temp_coh_file, keep_bits=10)
 
     stitched_shp_count_file = stitched_ifg_dir / "shp_counts.tif"
-    stitching.merge_images(
-        shp_count_file_list,
-        outfile=stitched_shp_count_file,
-        driver="GTiff",
-        out_bounds=out_bounds,
-        out_bounds_epsg=output_options.bounds_epsg,
-    )
+    if not stitched_shp_count_file.exists():
+        stitching.merge_images(
+            shp_count_file_list,
+            outfile=stitched_shp_count_file,
+            driver="GTiff",
+            resample_alg="nearest",
+            out_bounds=out_bounds,
+            out_bounds_epsg=output_options.bounds_epsg,
+        )
 
     stitched_similarity_file = stitched_ifg_dir / "similarity.tif"
-    stitching.merge_images(
-        similarity_file_list,
-        outfile=stitched_similarity_file,
-        driver="GTiff",
-        out_bounds=out_bounds,
-        out_bounds_epsg=output_options.bounds_epsg,
-    )
+    if not stitched_similarity_file.exists():
+        stitching.merge_images(
+            similarity_file_list,
+            outfile=stitched_similarity_file,
+            driver="GTiff",
+            resample_alg="nearest",
+            out_bounds=out_bounds,
+            out_bounds_epsg=output_options.bounds_epsg,
+        )
 
     if output_options.add_overviews:
         logger.info("Creating overviews for stitched images")


### PR DESCRIPTION
Closes #144

The `lanczos` filter was leading to pixels above 1 in the merged temporal coherence image, despite the max being 1.0 per burst.

This is also likely the reason for negative coherences, though we can reopen if any new instances are spotted (hasn't been seen in a year)


Before the fix:
```
# per-burst coherence (min, max, mean, stddev)
$ rio info --stats scratch/historical/t034_071057_iw2/linked_phase/temporal_coherence_average_20160927_20170326.tif
0.10250737518072128 1.0 0.5941266093428491 0.16596814123869957

# Stitched
$ rio info --stats scratch/historical/interferograms/temporal_coherence.tif
0.01056671142578125 1.15234375 0.5833594791456398 0.19027603197546147
```

and these were only happening on bursts which required reprojection:
```
$ rio info --crs scratch/historical/interferograms/temporal_coherence.tif
EPSG:32615
$ rio info --crs scratch/historical/t034_071057_iw2/linked_phase/temporal_coherence_average_20160927_20170326.tif
EPSG:32614
```