### PR TITLE
Use the most recent compressed SLC as output for `LAST_PER_MINISTACK`

### DIFF
--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -465,6 +465,7 @@ class MiniStackPlanner(BaseStack):
 
             if compressed_idx is not None:
                 compressed_reference_idx = compressed_idx
+                output_reference_idx = self.output_reference_idx
             elif self.compressed_slc_plan == CompressedSlcPlan.ALWAYS_FIRST:
                 # Simplest operational version: CompSLCs have same base phase,
                 # but different "residual" added on

--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -471,20 +471,27 @@ class MiniStackPlanner(BaseStack):
                 # We use the `output_reference_idx`, 0 by default, but this index
                 # may be passed in if we are manually specifying an output
                 compressed_reference_idx = self.output_reference_idx
+                output_reference_idx = self.output_reference_idx
             elif self.compressed_slc_plan == CompressedSlcPlan.FIRST_PER_MINISTACK:
                 # Like Ansari, 2017 paper: each ministack is "self contained"
                 compressed_reference_idx = num_ccslc
                 # Ansari, 2017 also had output_reference_idx = num_ccslcs, and
-                # use the "Datum Adjustment" step to get outputs relative to day 0
+                # used the "Datum Adjustment" step to get outputs relative to day 0
+                # Here, we'll use 0 (or manually specifed)
+                output_reference_idx = self.output_reference_idx
             elif self.compressed_slc_plan == CompressedSlcPlan.LAST_PER_MINISTACK:
                 # Alternative that allows sequential interferograms across ministacks
                 compressed_reference_idx = -1
+                # For this, we'll always use the most recent compressed SLC as output
+                # reference so that we can connected stacks, but minimize the temporal
+                # baseline of interferograms we form
+                output_reference_idx = num_ccslc - 1
 
             cur_ministack = MiniStackInfo(
                 file_list=combined_files,
                 dates=combined_dates,
                 is_compressed=combined_is_compressed,
-                output_reference_idx=self.output_reference_idx,
+                output_reference_idx=output_reference_idx,
                 compressed_reference_idx=compressed_reference_idx,
                 output_folder=cur_output_folder,
             )


### PR DESCRIPTION
The current imagined use case for `LAST_PER_MINISTACK` compressed SLC's is to always make the shortest possible baseline interferograms. This means a sensible default is to set the output reference to be the most recently created compressed SLC (i.e. `output_reference_idx = num_ccslc - 1`).

As expected, the tests on Kilauea show better results than if we include longer interferograms. 