### PR TITLE
Adapt short wavelength filter to use `gdal_fillnodata` to mitigate edge effects

### DIFF
--- a/src/dolphin/filtering.py
+++ b/src/dolphin/filtering.py
@@ -118,10 +118,22 @@ def filter_long_wavelength(
             max_distance=max_distance_pixels,
             smoothing_iterations=0,
             interpolation="nearest",
+            quiet=True,
         )
 
-    filled_data = io.load_gdal(temp_dst, masked=True)
+        filled_data = io.load_gdal(temp_dst, masked=True)
+
     padded = filled_data
+
+    # We need to find the new pixels which are valid after filling
+    # These are going to be out of bounds in the original image,
+    # but we don't want to ignore them during the low pass filter.
+    # The boundary pixels are the ones which will allow the edge values
+    # to be smoothed out without.
+    new_valid = np.isnan(displacement) & ~np.isnan(filled_data)
+
+    bad_pixel_mask_ext = bad_pixel_mask.copy()
+    bad_pixel_mask_ext[new_valid] = False
 
     # # Remove the plane, setting to 0 where we had no data for the plane fit:
     # unw_ifg_interp = np.where(total_valid_mask, displacement, 0)

--- a/src/dolphin/filtering.py
+++ b/src/dolphin/filtering.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import multiprocessing as mp
+import tempfile
 from concurrent.futures import ProcessPoolExecutor
 from itertools import repeat
 from pathlib import Path
@@ -8,6 +9,8 @@ from typing import Sequence
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
+from osgeo import gdal
+from osgeo_utils.gdal_fillnodata import gdal_fillnodata
 from scipy import fft, ndimage
 
 
@@ -18,6 +21,7 @@ def filter_long_wavelength(
     pixel_spacing: float = 30,
     workers: int = 1,
     fill_value: float | None = None,
+    scratch_dir: Path | None = None,
 ) -> np.ndarray:
     """Filter out signals with spatial wavelength longer than a threshold.
 
@@ -42,6 +46,9 @@ def filter_long_wavelength(
         Value to place in output pixels which were masked.
         If `None`, masked pixels are filled with the ramp value fitted
         before filtering to suppress outliers.
+    scratch_dir : Path, optional
+        Directory to use for temporary files. If not provided, uses system default
+        for Python's tempfile module.
 
     Returns
     -------
@@ -55,37 +62,80 @@ def filter_long_wavelength(
         If wavelength_cutoff too large for image size/pixel spacing.
 
     """
+    from dolphin import io
+
+    # Find the filter `sigma` which gives the correct cutoff in meters
+    sigma = _compute_filter_sigma(wavelength_cutoff, pixel_spacing, cutoff_value=0.5)
+    rows, cols = unwrapped_phase.shape
+
+    if sigma > rows or sigma > cols:
+        msg = f"{wavelength_cutoff = } too large for image."
+        msg += f"Shape = {(rows, cols)}, and {pixel_spacing = }"
+        raise ValueError(msg)
+
+    # Work on a copy of the displacement field to avoid modifying the input
+    displacement = np.nan_to_num(unwrapped_phase)
+
     good_pixel_mask = np.logical_not(bad_pixel_mask)
 
-    rows, cols = unwrapped_phase.shape
-    unw0 = np.nan_to_num(unwrapped_phase)
     # Take either nan or 0 pixels in `unwrapped_phase` to be nodata
-    nodata_mask = unw0 == 0
+    nodata_mask = displacement == 0
     in_bounds_pixels = np.logical_not(nodata_mask)
 
     total_valid_mask = in_bounds_pixels & good_pixel_mask
 
-    plane = fit_ramp_plane(unw0, total_valid_mask)
-    # Remove the plane, setting to 0 where we had no data for the plane fit:
-    unw_ifg_interp = np.where(total_valid_mask, unw0, plane)
+    # Convert bad pixels to NaN for GDAL fillnodata
+    displacement[bad_pixel_mask] = np.nan
 
-    # Find the filter `sigma` which gives the correct cutoff in meters
-    sigma = _compute_filter_sigma(wavelength_cutoff, pixel_spacing, cutoff_value=0.5)
+    # Calculate the number of pixels for max_distance based on wavelength
+    max_distance_pixels = int((wavelength_cutoff / 2) / pixel_spacing)
 
-    if sigma > unw0.shape[0] or sigma > unw0.shape[0]:
-        msg = f"{wavelength_cutoff = } too large for image."
-        msg += f"Shape = {(rows, cols)}, and {pixel_spacing = }"
-        raise ValueError(msg)
-    # Pad the array with edge values
-    # The padding extends further than the default "radius = 2*sigma + 1",
-    # which given specified in `gaussian_filter`
-    # https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.gaussian_filter.html#scipy.ndimage.gaussian_filter
-    pad_rows = pad_cols = int(3 * sigma)
-    # See here for illustration of `mode="reflect"`
-    # https://scikit-image.org/docs/stable/auto_examples/transform/plot_edge_modes.html#interpolation-edge-modes
-    padded = np.pad(
-        unw_ifg_interp, ((pad_rows, pad_rows), (pad_cols, pad_cols)), mode="reflect"
-    )
+    # Create temporary files for GDAL processing
+    temp_src = Path("temp_src.tif")
+    temp_dst = Path("temp_filled.tif")
+
+    scratch_dir = Path(scratch_dir) if scratch_dir is not None else None
+
+    # Create temporary directory in the specified location or system default
+    with tempfile.TemporaryDirectory(dir=scratch_dir) as temp_dir:
+        tmp_path = Path(temp_dir)
+        # Create paths for temporary files in the temp directory
+        temp_src = tmp_path / "src.tif"
+        temp_dst = tmp_path / "filled.tif"
+
+        # Save the array to a temporary GeoTIFF
+        driver = gdal.GetDriverByName("GTiff")
+        dset = driver.Create(str(temp_src), cols, rows, 1, gdal.GDT_Float32)
+        band = dset.GetRasterBand(1)
+        band.WriteArray(displacement)
+        band.SetNoDataValue(np.nan)
+        dset = None  # Close the dset
+
+        # Fill nodata using GDAL
+        gdal_fillnodata(
+            src_filename=str(temp_src),
+            dst_filename=str(temp_dst),
+            max_distance=max_distance_pixels,
+            smoothing_iterations=0,
+            interpolation="nearest",
+        )
+
+    filled_data = io.load_gdal(temp_dst, masked=True)
+    padded = filled_data
+
+    # # Remove the plane, setting to 0 where we had no data for the plane fit:
+    # unw_ifg_interp = np.where(total_valid_mask, displacement, 0)
+
+    # # Pad the array with edge values
+    # # The padding extends further than the default "radius = 2*sigma + 1",
+    # # which given specified in `gaussian_filter`
+    # # https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.gaussian_filter.html#scipy.ndimage.gaussian_filter
+    # pad_rows = pad_cols = int(3 * sigma)
+    # # See here for illustration of `mode="reflect"`
+    # # https://scikit-image.org/docs/stable/auto_examples/transform/plot_edge_modes.html#interpolation-edge-modes
+    # padded = np.pad(
+    #     unw_ifg_interp, ((pad_rows, pad_rows), (pad_cols, pad_cols)), mode="reflect"
+    # )
 
     # Apply Gaussian filter
     result = fft.fft2(padded, workers=workers)
@@ -94,9 +144,10 @@ def filter_long_wavelength(
     result = fft.ifft2(result, workers=workers).real.astype(unwrapped_phase.dtype)
 
     # Crop back to original size
-    lowpass_filtered = result[pad_rows:-pad_rows, pad_cols:-pad_cols]
+    # lowpass_filtered = result[pad_rows:-pad_rows, pad_cols:-pad_cols]
+    lowpass_filtered = result
 
-    filtered_ifg = unw_ifg_interp - lowpass_filtered * in_bounds_pixels
+    filtered_ifg = filled_data - lowpass_filtered * in_bounds_pixels
     if fill_value is not None:
         return np.where(total_valid_mask, filtered_ifg, fill_value)
     else:
@@ -110,46 +161,6 @@ def _compute_filter_sigma(
     sigma_x = 1 / np.pi / 2 / sigma_f
     sigma = sigma_x / pixel_spacing
     return sigma
-
-
-def fit_ramp_plane(unw_ifg: ArrayLike, mask: ArrayLike) -> np.ndarray:
-    """Fit a ramp plane to the given data.
-
-    Parameters
-    ----------
-    unw_ifg : ArrayLike
-        2D array where the unwrapped interferogram data is stored.
-    mask : ArrayLike
-        2D boolean array indicating the valid (non-NaN) pixels.
-
-    Returns
-    -------
-    np.ndarray
-        2D array of the fitted ramp plane.
-
-    """
-    # Extract data for non-NaN & masked pixels
-    Y = unw_ifg[mask]
-    Xdata = np.argwhere(mask)  # Get indices of non-NaN & masked pixels
-
-    # Include the intercept term (bias) in the model
-    X = np.c_[np.ones((len(Xdata))), Xdata]
-
-    # Compute the parameter vector theta using the least squares solution
-    theta = np.linalg.pinv(X.T @ X) @ X.T @ Y
-
-    # Prepare grid for the entire image
-    nrow, ncol = unw_ifg.shape
-    X1_, X2_ = np.mgrid[:nrow, :ncol]
-    X_ = np.hstack(
-        (np.reshape(X1_, (nrow * ncol, 1)), np.reshape(X2_, (nrow * ncol, 1)))
-    )
-    X_ = np.hstack((np.ones((nrow * ncol, 1)), X_))
-
-    # Compute the fitted plane
-    plane = np.reshape(X_ @ theta, (nrow, ncol))
-
-    return plane
 
 
 def filter_rasters(

--- a/src/dolphin/filtering.py
+++ b/src/dolphin/filtering.py
@@ -117,7 +117,7 @@ def filter_long_wavelength(
             quiet=True,
         )
 
-        filled_data = io.load_gdal(temp_dst, masked=True)
+        filled_data = io.load_gdal(temp_dst, masked=True).filled(0)
 
     # Apply Gaussian filter
     lowpass_filtered = fft.fft2(filled_data, workers=workers)

--- a/src/dolphin/phase_link/simulate.py
+++ b/src/dolphin/phase_link/simulate.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import numpy as np
 import numpy.linalg as la
 import scipy.ndimage as ndi
+from numba import njit
 from numpy.typing import ArrayLike
 
 
+@njit(cache=True)
 def _ccg_noise(N: int) -> np.array:
     return (np.random.randn(N) + 1j * np.random.randn(N)) / np.sqrt(2)
 
@@ -19,6 +21,7 @@ def _ccg_noise(N: int) -> np.array:
 rng = np.random.default_rng()
 
 
+@njit(cache=True)
 def _seed(a):
     """Seed the random number generator for numba.
 
@@ -72,7 +75,6 @@ def simulate_coh(
     acq_interval: int = 12,
     add_signal: bool = False,
     signal_std: float = 0.1,
-    use_seasonal_coherence: bool = False,
 ) -> np.array:
     """Simulate a correlation matrix for a pixel.
 
@@ -92,8 +94,6 @@ def simulate_coh(
         Whether to add a simulated signal.
     signal_std : float
         The standard deviation of the simulated signal.
-    use_seasonal_coherence : bool
-        Whether to use a seasonal coherence model.
 
     Returns
     -------
@@ -116,14 +116,7 @@ def simulate_coh(
     else:
         noisy_truth = truth = np.zeros(len(time), dtype=np.float64)
 
-    C = simulate_coh_stack(
-        time,
-        gamma0,
-        gamma_inf,
-        Tau0,
-        noisy_truth,
-        use_seasonal_coherence=use_seasonal_coherence,
-    ).squeeze()
+    C = simulate_coh_stack(time, gamma0, gamma_inf, Tau0, noisy_truth).squeeze()
     return C, truth
 
 
@@ -134,7 +127,6 @@ def simulate_coh_stack(
     Tau0: np.ndarray,
     signal: np.ndarray,
     amplitudes: ArrayLike | None = None,
-    use_seasonal_coherence: bool = False,
 ) -> np.ndarray:
     """Create a coherence matrix at each pixel.
 
@@ -154,8 +146,6 @@ def simulate_coh_stack(
     amplitudes: ArrayLike, optional
         If provided, set the amplitudes of the output pixels.
         Default is to use all ones.
-    use_seasonal_coherence : bool
-        Whether to use a seasonal coherence model.
 
     Returns
     -------
@@ -171,23 +161,13 @@ def simulate_coh_stack(
     Tau0 = np.atleast_2d(Tau0)[:, :, None, None]
     if amplitudes is None:
         amplitudes = np.ones((num_time, 1, 1), dtype=np.float32)
+
+    gamma = (gamma0 - gamma_inf) * np.exp(time_diff / Tau0) + gamma_inf
+    phase_diff = signal[:, None] - signal[None, :]
     # Multiply each pixel by (a a^T)
     A = np.einsum("irc,jrc->rcij", amplitudes, amplitudes)
+    C = A * gamma * np.exp(1j * phase_diff)
 
-    phase_diff = signal[:, None] - signal[None, :]
-    C = A * np.exp(1j * phase_diff)
-    exp_decay = (gamma0 - gamma_inf) * np.exp(time_diff / Tau0) + gamma_inf
-    C = C * exp_decay
-
-    if use_seasonal_coherence:
-        a_factor = 0.5 * (1 + np.sqrt(gamma_inf))
-        b_factor = 0.5 * (1 - np.sqrt(gamma_inf))
-        seasonal_factor = (
-            a_factor + b_factor * np.cos(2 * np.pi * time_diff / 365.25)
-        ) ** 2
-        # Ensure it is a valid coherence multiplier
-        seasonal_factor = np.clip(seasonal_factor, 0, 1)
-        C = C * seasonal_factor
     rl, cl = np.tril_indices(num_time, k=-1)
 
     C[..., rl, cl] = np.conj(np.transpose(C, axes=(0, 1, 3, 2))[..., rl, cl])
@@ -251,6 +231,7 @@ def rmse(x, y, axis=None):
     return np.sqrt(np.mean((x - y) ** 2, axis=axis))
 
 
+@njit(cache=True)
 def mle(cov_mat, beta=0.00):
     """Estimate the linked phase using the MLE estimator.
 
@@ -285,6 +266,7 @@ def mle(cov_mat, beta=0.00):
     return evd_estimate.astype(dtype)
 
 
+@njit(cache=True)
 def evd(cov_mat):
     """Estimate the linked phase the largest eigenvector of `cov_mat`."""
     # estimate the wrapped phase based on the eigenvalue decomp of the cov. matrix

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -10,12 +10,16 @@ def test_filter_long_wavelength():
     # Check filtering with ramp phase
     y, x = np.ogrid[-3:3:512j, -3:3:512j]
     unw_ifg = np.pi * (x + y)
+
     corr = np.ones(unw_ifg.shape, dtype=np.float32)
     bad_pixel_mask = corr < 0.5
 
     # Filtering
     filtered_ifg = filtering.filter_long_wavelength(
-        unw_ifg, bad_pixel_mask=bad_pixel_mask, pixel_spacing=1000
+        unw_ifg,
+        bad_pixel_mask=bad_pixel_mask,
+        pixel_spacing=100,
+        wavelength_cutoff=1_000,
     )
     np.testing.assert_allclose(
         filtered_ifg[10:-10, 10:-10],


### PR DESCRIPTION
Testing on a horizontal ramp:
<img width="511" alt="image" src="https://github.com/user-attachments/assets/894cfb74-21fd-40a6-b462-93271173d605" />

the main branch leaves an edge effect:
<img width="512" alt="image" src="https://github.com/user-attachments/assets/94206c17-2cf8-4759-9f0c-afd04d2ce5a5" />

This PR gives all zeros, as we would want.

Sanity check on small, real unwrapping interferogram looks okay as well.
<img width="1018" alt="image" src="https://github.com/user-attachments/assets/913c984c-27a2-401b-9dbb-ba70786bfbdc" />
