### PR TITLE
Add `keepdims` options to reader classes to avoid squeezing singleton dims

### DIFF
--- a/src/dolphin/io/_readers.py
+++ b/src/dolphin/io/_readers.py
@@ -417,7 +417,7 @@ def _read_3d(
     key: tuple[Index, ...],
     readers: Sequence[DatasetReader],
     num_threads: int = 1,
-    keepdims: bool = False,
+    keepdims: bool = True,
 ):
     bands, r_slice, c_slice = _unpack_3d_slices(key)
 
@@ -448,7 +448,7 @@ class BaseStackReader(StackReader):
 
     file_list: Sequence[Filename]
     readers: Sequence[DatasetReader]
-    keepdims: bool = False
+    keepdims: bool = True
     num_threads: int = 1
     nodata: Optional[float] = None
 
@@ -636,7 +636,7 @@ class RasterStackReader(BaseStackReader):
         cls,
         file_list: Sequence[Filename],
         bands: int | Sequence[int] = 1,
-        keepdims: bool = False,
+        keepdims: bool = True,
         keep_open: bool = False,
         num_threads: int = 1,
         nodata: Optional[float] = None,

--- a/src/dolphin/io/_readers.py
+++ b/src/dolphin/io/_readers.py
@@ -242,6 +242,10 @@ class HDF5Reader(DatasetReader):
     keep_open: bool = False
     """bool : If True, keep the HDF5 file handle open for faster reading."""
 
+    keepdims: bool = True
+    """bool : Maintain the dimension of the point array. If set to False, will
+    skip `squeeze` on outputs with one dimension size of 1. Default is True."""
+
     def __post_init__(self):
         filename = Path(self.filename)
 
@@ -328,12 +332,17 @@ class RasterReader(DatasetReader):
     chunks: Optional[tuple[int, int]] = None
     """Optional[tuple[int, int]] : Chunk shape of the dataset, or None if unchunked."""
 
+    keepdims: bool = True
+    """bool : Maintain the dimension of the point array. If set to False, will
+    skip `squeeze` on outputs with one dimension size of 1. Default is True."""
+
     @classmethod
     def from_file(
         cls,
         filename: Filename,
         band: int = 1,
         nodata: Optional[float] = None,
+        keepdims: bool = True,
         keep_open: bool = False,
         **options,
     ) -> RasterReader:
@@ -355,6 +364,7 @@ class RasterReader(DatasetReader):
                 shape=shape,
                 dtype=dtype,
                 nodata=nodata,
+                keepdims=keepdims,
                 keep_open=keep_open,
                 chunks=chunks,
             )
@@ -397,11 +407,17 @@ class RasterReader(DatasetReader):
         # Note that Rasterio doesn't use the `step` of a slice, so we need to
         # manually slice the output array.
         r_step, c_step = r_slice.step or 1, c_slice.step or 1
-        return out_masked[::r_step, ::c_step].squeeze()
+        if self.keepdims:
+            return out_masked[::r_step, ::c_step]
+        else:
+            return out_masked[::r_step, ::c_step].squeeze()
 
 
 def _read_3d(
-    key: tuple[Index, ...], readers: Sequence[DatasetReader], num_threads: int = 1
+    key: tuple[Index, ...],
+    readers: Sequence[DatasetReader],
+    num_threads: int = 1,
+    keepdims: bool = False,
 ):
     bands, r_slice, c_slice = _unpack_3d_slices(key)
 
@@ -423,8 +439,7 @@ def _read_3d(
             results = executor.map(lambda i: readers[i][r_slice, c_slice], band_idxs)
         out = np.stack(list(results), axis=0)
 
-    # TODO: Do i want a "keep_dims" option to not collapse singleton dimensions?
-    return np.squeeze(out)
+    return out if keepdims else np.squeeze(out)
 
 
 @dataclass
@@ -433,11 +448,14 @@ class BaseStackReader(StackReader):
 
     file_list: Sequence[Filename]
     readers: Sequence[DatasetReader]
+    keepdims: bool = False
     num_threads: int = 1
     nodata: Optional[float] = None
 
     def __getitem__(self, key: tuple[Index, ...], /) -> np.ndarray:
-        return _read_3d(key, self.readers, num_threads=self.num_threads)
+        return _read_3d(
+            key, self.readers, num_threads=self.num_threads, keepdims=self.keepdims
+        )
 
     @property
     def shape_2d(self):
@@ -618,6 +636,7 @@ class RasterStackReader(BaseStackReader):
         cls,
         file_list: Sequence[Filename],
         bands: int | Sequence[int] = 1,
+        keepdims: bool = False,
         keep_open: bool = False,
         num_threads: int = 1,
         nodata: Optional[float] = None,
@@ -632,6 +651,10 @@ class RasterStackReader(BaseStackReader):
             Band to read from each file.
             If a single int, will be used for all files.
             Default = 1.
+        keepdims : bool
+            Maintain the dimension of the point array. If set to False, will
+            skip `squeeze` on outputs with one dimension size of 1.
+            Default is False.
         keep_open : bool, optional (default False)
             If True, keep the rasterio file handles open for faster reading.
         num_threads : int, optional (default 1)
@@ -649,14 +672,20 @@ class RasterStackReader(BaseStackReader):
             bands = [bands] * len(file_list)
 
         readers = [
-            RasterReader.from_file(f, band=b, keep_open=keep_open)
+            RasterReader.from_file(f, band=b, keep_open=keep_open, keepdims=keepdims)
             for (f, b) in zip(file_list, bands)
         ]
         # Check if nodata values were found in the files
         nds = {r.nodata for r in readers}
         if len(nds) == 1:
             nodata = nds.pop()
-        return cls(file_list, readers, num_threads=num_threads, nodata=nodata)
+        return cls(
+            file_list,
+            readers,
+            num_threads=num_threads,
+            nodata=nodata,
+            keepdims=keepdims,
+        )
 
 
 # Masked versions of each of the 2D/3D readers

--- a/tests/test_io_readers.py
+++ b/tests/test_io_readers.py
@@ -22,7 +22,9 @@ from dolphin.utils import _get_path_from_gdal_str
 # Note: uses the fixtures from conftest.py
 
 # Get combinations of slices
-slices_to_test = [slice(None), 1, slice(0, 10, 2)]
+# TODO: if we want to test `1`, and have it work the same as
+# numpy slicing which drops the dimension, we'll need to change this
+slices_to_test = [slice(None), slice(1), slice(0, 10, 2)]
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_io_readers.py
+++ b/tests/test_io_readers.py
@@ -174,7 +174,40 @@ def raster_reader(slc_file_list, slc_stack):
     return r
 
 
-class TestRaster:
+@pytest.fixture(scope="module")
+def image_513(tmp_path_factory):
+    from dolphin import io
+
+    tmp_path = tmp_path_factory.mktemp("data")
+    shape = (65, 65)
+    d = tmp_path / "shape513"
+    d.mkdir()
+
+    name = d / "image.tif"
+
+    data = np.random.rand(*shape)
+    io.write_arr(arr=data, output_name=name)
+    return name
+
+
+def test_single_pixel_leftover_squeeze(image_513):
+    # ignore georeferencing warnings
+    with pytest.warns(rio.errors.NotGeoreferencedWarning):
+        r = RasterReader.from_file(image_513, keepdims=True)
+        r2 = RasterReader.from_file(image_513, keepdims=False)
+
+    d = r[slice(64, 65), slice(0, 25)]
+    assert d.shape == (1, 25)
+    assert d.ndim == 2
+    assert r[slice(64, 65), slice(64, 65)].ndim == 2
+
+    d = r2[slice(64, 65), slice(0, 25)]
+    assert d.ndim == 1
+    assert d.shape == (25,)
+    assert r2[slice(64, 65), slice(64, 65)].ndim == 0
+
+
+class TestRasterStack:
     @pytest.mark.parametrize("keep_open", [True, False])
     def test_raster_stack_reader(
         self,
@@ -206,6 +239,20 @@ class TestRaster:
         expected = slc_stack[dslice, rslice, cslice]
         assert s.shape == expected.shape
         npt.assert_array_almost_equal(s, expected)
+
+    def test_single_pixel_leftover_squeeze(self, image_513):
+        with pytest.warns(rio.errors.NotGeoreferencedWarning):
+            reader = RasterStackReader.from_file_list(
+                [image_513, image_513], keepdims=True
+            )
+            reader_sq = RasterStackReader.from_file_list(
+                [image_513, image_513], keepdims=False
+            )
+        d = reader[:, slice(64, 65), slice(64, 65)]
+        assert d.shape == (2, 1, 1)
+
+        d2 = reader_sq[:, slice(64, 65), slice(64, 65)]
+        assert d2.shape == (2,)
 
 
 @pytest.mark.parametrize("rows", slices_to_test)


### PR DESCRIPTION
Slices like `slice(n, n+1)` currently get squeezed out of the `RasterReader` and `RasterStackReader` classes.

~TBD: if we should make the default `keepdims=True`, or make the default the same as current behavior with `keepdims=False`.~
I have made the default `keepdims=True`, since, in dolphin, we are really using these dataset readers in the context of block-based processing. There are more headaches involved with a dimension accidentally dropping out than having an extra singleton dimension. Since we're adding this as an init option, there's still the ability to squeeze out dimensions if desired for other purposes.