### PR TITLE
Remove import for `goldstein` and `filtering` from top level `__init_.py`

### DIFF
--- a/src/dolphin/__init__.py
+++ b/src/dolphin/__init__.py
@@ -5,5 +5,3 @@ from dolphin._version import version as __version__
 from ._log import *
 from ._show_versions import *
 from ._types import *
-from .goldstein import goldstein
-from .interpolation import interpolate

--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -953,7 +953,7 @@ def invert_unw_network(
 
     """
     if ifg_date_pairs is None:
-        ifg_date_pairs = [get_dates(f) for f in unw_file_list]
+        ifg_date_pairs = [get_dates(f)[:2] for f in unw_file_list]
 
     try:
         # Ensure it's a list of pairs

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -10,8 +10,10 @@ from typing import Optional, Sequence
 import numpy as np
 from tqdm.auto import tqdm
 
-from dolphin import goldstein, interpolate, io
+from dolphin import io
 from dolphin._types import Filename
+from dolphin.goldstein import goldstein
+from dolphin.interpolation import interpolate
 from dolphin.utils import DummyProcessPoolExecutor, full_suffix
 from dolphin.workflows import UnwrapMethod, UnwrapOptions
 


### PR DESCRIPTION
The interpolate one gets numba, unwrap, leads to much longer import times for CLIs

Also fix the `get_dates` within time series for cases with longer filenames.
