### PR TITLE
Refactor `select_reference_point` to pick the centroid of high-coherence candidate pixels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
   - Picks the center of mass instead of arbitrary `argmax` result
   - Rename `condition_file` to `quality_file`
 
-### Changed
-- Removed `condition` parameter in `timeeries` reference point functions
+### Removed
+
+- Removed `condition` parameter in `timeseries` reference point functions
 - Removed `CallFunc` enum
 
 ## [0.35.1](https://github.com/isce-framework/dolphin/compare/v0.35.0...v0.35.1) - 2025-01-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,26 @@
 # Changelog
 
-## [Unreleased](https://github.com/isce-framework/dolphin/compare/v0.30.0...main)
+## [Unreleased](https://github.com/isce-framework/dolphin/compare/v0.35.1...main)
 
-## [0.35.0](https://github.com/isce-framework/dolphin/compare/v0.34.0...v0.35.0) - 2025-12-09
+### Changed
+
+- `timeseries.py`: Auto reference point selection
+  - Picks the center of mass instead of arbitrary `argmax` result
+  - Rename `condition_file` to `quality_file`
+
+### Changed
+- Removed `condition` parameter in `timeeries` reference point functions
+- Removed `CallFunc` enum
+
+## [0.35.1](https://github.com/isce-framework/dolphin/compare/v0.35.0...v0.35.1) - 2025-01-15
+
+### Fixed
+
+- `filtering.py` Fix in_bounds_pixels masking, set default to 25 km
+- Set `output_reference_idx` separately from `compressed_reference_idx` during phase linking setup
+
+
+## [0.35.0](https://github.com/isce-framework/dolphin/compare/v0.34.0...v0.35.0) - 2025-01-09
 
 ### Added
 

--- a/src/dolphin/_cli_timeseries.py
+++ b/src/dolphin/_cli_timeseries.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 
 from dolphin._log import setup_logging
 from dolphin.timeseries import InversionMethod
-from dolphin.workflows import CallFunc
 
 if TYPE_CHECKING:
     _SubparserType = argparse._SubParsersAction[argparse.ArgumentParser]
@@ -57,19 +56,10 @@ def get_parser(subparser=None, subcommand_name="timeseries") -> argparse.Argumen
         ),
     )
     parser.add_argument(
-        "--condition-file",
+        "--quality-file",
         help=(
             "A file with the same size as each raster, like amplitude dispersion or "
             "temporal coherence to find reference point"
-        ),
-    )
-    parser.add_argument(
-        "--condition",
-        type=CallFunc,
-        default=CallFunc.MIN,
-        help=(
-            "A condition to apply to condition file to find the reference point. "
-            "Options are [min, max]. default=min"
         ),
     )
     parser.add_argument(

--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -1240,7 +1240,7 @@ def select_reference_point(
                 num_threads=num_threads,
             )
         except ReferencePointError:
-            msg = "Unable to find find a connected component intersection."
+            msg = "Unable to find a connected component intersection."
             msg += f"Proceeding using only {quality_file = }"
             logger.warning(msg, exc_info=True)
 

--- a/src/dolphin/workflows/config/_enums.py
+++ b/src/dolphin/workflows/config/_enums.py
@@ -1,7 +1,6 @@
 from enum import Enum
 
 __all__ = [
-    "CallFunc",
     "ShpMethod",
     "UnwrapMethod",
 ]
@@ -25,10 +24,3 @@ class UnwrapMethod(str, Enum):
     PHASS = "phass"
     SPURT = "spurt"
     WHIRLWIND = "whirlwind"
-
-
-class CallFunc(str, Enum):
-    """Call function for the timeseries method to find reference point."""
-
-    MIN = "min"
-    MAX = "max"

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -259,9 +259,9 @@ def run(
             unwrapped_paths=unwrapped_paths,
             conncomp_paths=conncomp_paths,
             corr_paths=stitched_paths.interferometric_corr_paths,
+            # TODO: Right now we don't have the option to pick a different candidate
+            # or quality file. Figure out if this is worth exposing
             quality_file=stitched_paths.temp_coh_file,
-            # TODO: Right now aew don't have the option to pick a different candidate
-            # or quality file.
             reference_candidate_threshold=0.95,
             output_dir=ts_opts._directory,
             method=timeseries.InversionMethod(ts_opts.method),

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -16,7 +16,6 @@ from tqdm.auto import tqdm
 from dolphin import __version__, io, timeseries, utils
 from dolphin._log import log_runtime, setup_logging
 from dolphin.timeseries import ReferencePoint
-from dolphin.workflows import CallFunc
 
 from . import stitching_bursts, unwrapping, wrapped_phase
 from ._utils import _create_burst_cfg, _remove_dir_if_empty, parse_ionosphere_files
@@ -260,8 +259,10 @@ def run(
             unwrapped_paths=unwrapped_paths,
             conncomp_paths=conncomp_paths,
             corr_paths=stitched_paths.interferometric_corr_paths,
-            condition_file=stitched_paths.temp_coh_file,
-            condition=CallFunc.MAX,
+            quality_file=stitched_paths.temp_coh_file,
+            # TODO: Right now aew don't have the option to pick a different candidate
+            # or quality file.
+            reference_candidate_threshold=0.95,
             output_dir=ts_opts._directory,
             method=timeseries.InversionMethod(ts_opts.method),
             run_velocity=ts_opts.run_velocity,

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -7,7 +7,6 @@ import pytest
 from numpy.linalg import lstsq as lstsq_numpy
 
 from dolphin import io, timeseries
-from dolphin.timeseries import CallFunc
 from dolphin.utils import format_dates
 
 NUM_DATES = 10
@@ -283,9 +282,8 @@ class TestReferencePoint:
         io.write_arr(arr=arr, output_name=coh_file)
 
         ref_point = timeseries.select_reference_point(
-            condition_file=coh_file,
+            quality_file=coh_file,
             output_dir=tmp_path,
-            condition=CallFunc.MAX,
             candidate_threshold=0.95,  # everything is above 0.95
             ccl_file_list=None,
         )
@@ -303,9 +301,8 @@ class TestReferencePoint:
         io.write_arr(arr=arr, output_name=coh_file)
 
         ref_point = timeseries.select_reference_point(
-            condition_file=coh_file,
+            quality_file=coh_file,
             output_dir=tmp_path,
-            condition=CallFunc.MAX,
             candidate_threshold=0.95,
             ccl_file_list=None,
         )
@@ -342,9 +339,8 @@ class TestReferencePoint:
 
         ref_point = timeseries.select_reference_point(
             ccl_file_list=[ccl_file1, ccl_file2],
-            condition_file=coh_file,
+            quality_file=coh_file,
             output_dir=tmp_path,
-            condition=CallFunc.MAX,
             candidate_threshold=0.95,
         )
 


### PR DESCRIPTION
The default choice right now uses `argmax`, which, by numpy ordering, will be the edge of the possible pixels:
![image](https://github.com/user-attachments/assets/39105201-4677-4cb6-a800-c04f739876ff)

A safe one is more toward the center of the biggest connected component intersection. 
Scipy has the `center_of_mass` function, with the caveat being that the exact centroid may not one of the candidate pixels.