### PR TITLE
docs: Fix mathjax render, fix broken `DateOrDatetime` error

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -9,10 +9,11 @@ window.MathJax = {
     ignoreHtmlClass: ".*|",
     processHtmlClass: "arithmatex"
   }
-  };
+};
 
-  document$.subscribe(() => {
-
-
+document$.subscribe(() => {
+  MathJax.startup.output.clearCache()
+  MathJax.typesetClear()
+  MathJax.texReset()
   MathJax.typesetPromise()
 })

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,8 +46,7 @@ markdown_extensions:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 
 watch:

--- a/src/dolphin/_types.py
+++ b/src/dolphin/_types.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 import sys
 from enum import Enum
 from os import PathLike
@@ -72,8 +71,6 @@ class HalfWindow(NamedTuple):
 # Used for callable types
 T = TypeVar("T")
 P = ParamSpec("P")
-
-DateOrDatetime = Union[datetime.datetime, datetime.date]
 
 
 class ReferencePoint(NamedTuple):

--- a/src/dolphin/interferogram.py
+++ b/src/dolphin/interferogram.py
@@ -1,10 +1,11 @@
-"""Combine estimated DS phases with PS phases to form interferograms."""
+"""Module for creating interferograms and networks of interferograms."""
 
 from __future__ import annotations
 
 import itertools
 import logging
 from dataclasses import dataclass
+from datetime import date, datetime
 from os import fspath
 from pathlib import Path
 from typing import Any, Iterable, Literal, Optional, Sequence, Union
@@ -17,12 +18,13 @@ from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_va
 from tqdm.contrib.concurrent import thread_map
 
 from dolphin import io, utils
-from dolphin._types import DateOrDatetime, Filename, T
+from dolphin._types import Filename, T
 from dolphin.filtering import gaussian_filter_nan
 
 gdal.UseExceptions()
 
 logger = logging.getLogger(__name__)
+DateOrDatetime = Union[datetime, date]
 
 DEFAULT_SUFFIX = ".int.vrt"
 
@@ -248,10 +250,6 @@ class VRTInterferogram(BaseModel, extra="allow"):
         xsize, ysize = io.get_raster_xysize(self.path)
         return (ysize, xsize)
 
-    @property
-    def dates(self):  # noqa: D102
-        return (self.ref_date, self.sec_date)
-
     @classmethod
     def from_vrt_file(cls, path: Filename) -> VRTInterferogram:
         """Load a VRTInterferogram from an existing VRT file.
@@ -312,7 +310,7 @@ class Network:
         Date format to use when parsing dates from the input files (only
         used if setting `max_temporal_baseline`).
         defaults to '%Y%m%d'.
-    dates: Sequence[DateOrDatetime], optional
+    dates: Sequence[datetime | date], optional
         Alternative to `date_format`: manually specify the date/datetime of each item in
         `slc_list` instead of parsing the name.
         Only used for `max_temporal_baseline` networks.

--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -14,10 +14,11 @@ import numpy as np
 from opera_utils import get_dates
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from dolphin._types import DateOrDatetime, Filename
+from dolphin._types import Filename
 from dolphin.io import DEFAULT_DATETIME_FORMAT
 from dolphin.utils import format_dates
 
+DateOrDatetime = datetime | date
 logger = logging.getLogger(__name__)
 
 

--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -15,14 +15,14 @@ from numpy.typing import ArrayLike, NDArray
 from opera_utils import get_dates
 from scipy import ndimage
 
-from dolphin import DateOrDatetime, io
+from dolphin import io
 from dolphin._overviews import ImageType, create_overviews
 from dolphin._types import PathOrStr, ReferencePoint
 from dolphin.utils import flatten, format_dates, full_suffix, get_nearest_date_idx
 from dolphin.workflows import CallFunc
 
 T = TypeVar("T")
-
+DateOrDatetime = datetime | date
 logger = logging.getLogger(__name__)
 
 __all__ = ["run"]
@@ -1124,7 +1124,7 @@ def _get_residuals_per_date(
     Parameters
     ----------
     A : ArrayLike
-       The matrix A in the equation Ax = b.
+        The matrix A in the equation Ax = b.
     x_stack : ArrayLike
         The 3D stack of solved phases from the inversion.
         Shape is (n_dates, n_rows, n_cols)

--- a/tests/test_interferogram.py
+++ b/tests/test_interferogram.py
@@ -20,7 +20,8 @@ def test_derived_vrt_interferogram(slc_file_list):
 
     assert ifg.path.name == "20220101_20220102.int.vrt"
     assert io.get_raster_xysize(ifg.path) == io.get_raster_xysize(slc_file_list[0])
-    assert ifg.dates == (datetime(2022, 1, 1), datetime(2022, 1, 2))
+    assert ifg.ref_date == datetime(2022, 1, 1)
+    assert ifg.sec_date == datetime(2022, 1, 2)
 
     arr0 = io.load_gdal(slc_file_list[0])
     arr1 = io.load_gdal(slc_file_list[1])
@@ -31,9 +32,7 @@ def test_derived_vrt_interferogram(slc_file_list):
 
 def test_specify_dates(slc_file_list):
     ref_slc, sec_slc = slc_file_list[0:2]
-    ref_date, sec_date = datetime(2022, 1, 1), datetime(2022, 1, 2)
     ifg = VRTInterferogram(ref_slc=ref_slc, sec_slc=sec_slc)
-    assert ifg.dates == (ref_date, sec_date)
     assert ifg.path.name == "20220101_20220102.int.vrt"
 
     # Check other dates don't fail or get overwritten
@@ -42,14 +41,14 @@ def test_specify_dates(slc_file_list):
     ifg = VRTInterferogram(
         ref_slc=ref_slc, sec_slc=sec_slc, ref_date=ref_date2, sec_date=sec_date2
     )
-    assert ifg.dates == (ref_date2, sec_date2)
+    assert ifg.ref_date == ref_date2
+    assert ifg.sec_date == sec_date2
     assert ifg.path.name == "20230202_20230203.int.vrt"
+
     # One at a time check
     ifg = VRTInterferogram(ref_slc=ref_slc, sec_slc=sec_slc, ref_date=ref_date2)
-    assert ifg.dates == (ref_date2, sec_date)
     assert ifg.path.name == "20230202_20220102.int.vrt"
     ifg = VRTInterferogram(ref_slc=ref_slc, sec_slc=sec_slc, sec_date=sec_date2)
-    assert ifg.dates == (ref_date, sec_date2)
     assert ifg.path.name == "20220101_20230203.int.vrt"
 
 


### PR DESCRIPTION
Unclear exactly why this fails in mkdocstrings: https://readthedocs.org/projects/dolphin-insar/builds/27059026/

Also changes the mathjax snippets based on more recent suggestions here: https://squidfunk.github.io/mkdocs-material/reference/math/#mathjax