### PR TITLE
Replace `__name__` with "dolphin" in `getLogger` calls

### DIFF
--- a/src/dolphin/_decorators.py
+++ b/src/dolphin/_decorators.py
@@ -7,7 +7,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Callable
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 __all__ = [
     "atomic_output",

--- a/src/dolphin/_log.py
+++ b/src/dolphin/_log.py
@@ -83,7 +83,7 @@ def log_runtime(f: Callable[P, T]) -> Callable[P, T]:
     def test_func():
         return 2 + 4
     """
-    logger = logging.getLogger(__name__)
+    logger = logging.getLogger("dolphin")
 
     @wraps(f)
     def wrapper(*args: P.args, **kwargs: P.kwargs):

--- a/src/dolphin/_overviews.py
+++ b/src/dolphin/_overviews.py
@@ -14,7 +14,7 @@ from dolphin._types import PathOrStr
 
 gdal.UseExceptions()
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 DEFAULT_LEVELS = [4, 8, 16, 32, 64]
 

--- a/src/dolphin/atmosphere/_netcdf.py
+++ b/src/dolphin/atmosphere/_netcdf.py
@@ -15,7 +15,7 @@ from scipy.interpolate import RegularGridInterpolator as Interpolator
 
 from dolphin._types import Filename, TropoModel
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 ###########
 # Mostly inherited from RAiDER

--- a/src/dolphin/atmosphere/ionosphere.py
+++ b/src/dolphin/atmosphere/ionosphere.py
@@ -19,7 +19,7 @@ from dolphin._types import Bbox, Filename
 from dolphin.timeseries import ReferencePoint
 from dolphin.utils import format_date_pair
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 ###########
 

--- a/src/dolphin/atmosphere/troposphere.py
+++ b/src/dolphin/atmosphere/troposphere.py
@@ -22,7 +22,7 @@ from dolphin.utils import format_date_pair
 
 from ._netcdf import delay_from_netcdf, group_netcdf_by_date
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 ###########
 

--- a/src/dolphin/atmosphere/weather_model.py
+++ b/src/dolphin/atmosphere/weather_model.py
@@ -13,7 +13,7 @@ from shapely.geometry import box
 import dolphin.atmosphere._utils as utils
 import dolphin.atmosphere.model_levels as ml
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 _ZMIN = np.float64(-100)  # minimum required height
 _ZREF = np.float64(26000)  # maximum integration height

--- a/src/dolphin/interferogram.py
+++ b/src/dolphin/interferogram.py
@@ -23,7 +23,7 @@ from dolphin.filtering import gaussian_filter_nan
 
 gdal.UseExceptions()
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 DateOrDatetime = Union[datetime, date]
 
 DEFAULT_SUFFIX = ".int.vrt"

--- a/src/dolphin/interpolation.py
+++ b/src/dolphin/interpolation.py
@@ -8,7 +8,7 @@ from numpy.typing import ArrayLike
 
 from .similarity import get_circle_idxs
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 def interpolate(

--- a/src/dolphin/io/_background.py
+++ b/src/dolphin/io/_background.py
@@ -5,7 +5,7 @@ import logging
 from queue import Empty, Full, Queue
 from threading import Event, Thread, main_thread
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 _DEFAULT_TIMEOUT = 0.5
 

--- a/src/dolphin/io/_blocks.py
+++ b/src/dolphin/io/_blocks.py
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 @dataclass(frozen=True)

--- a/src/dolphin/io/_core.py
+++ b/src/dolphin/io/_core.py
@@ -25,7 +25,7 @@ from dolphin.utils import compute_out_shape, gdal_to_numpy_type, numpy_to_gdal_t
 from ._paths import S3Path
 
 gdal.UseExceptions()
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 __all__ = [
     "DEFAULT_DATETIME_FORMAT",

--- a/src/dolphin/io/_paths.py
+++ b/src/dolphin/io/_paths.py
@@ -12,7 +12,7 @@ from dolphin._types import GeneralPath
 __all__ = ["S3Path"]
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 class S3Path(GeneralPath):

--- a/src/dolphin/io/_readers.py
+++ b/src/dolphin/io/_readers.py
@@ -31,7 +31,7 @@ from ._background import _DEFAULT_TIMEOUT, BackgroundReader
 from ._paths import S3Path
 from ._utils import _ensure_slices, _unpack_3d_slices
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 __all__ = [
     "BinaryReader",

--- a/src/dolphin/log-config.json
+++ b/src/dolphin/log-config.json
@@ -12,7 +12,7 @@
                 "timestamp": "timestamp",
                 "message": "message",
                 "level": "levelname",
-                "logger": "name",
+                "filename": "filename",
                 "function": "funcName",
                 "line": "lineno",
                 "thread_name": "threadName"
@@ -27,11 +27,9 @@
             "stream": "ext://sys.stderr"
         },
         "file": {
-            "class": "logging.handlers.RotatingFileHandler",
+            "class": "logging.FileHandler",
             "level": "INFO",
-            "formatter": "json",
-            "maxBytes": 10000000,
-            "backupCount": 3
+            "formatter": "json"
         }
     },
     "loggers": {

--- a/src/dolphin/masking.py
+++ b/src/dolphin/masking.py
@@ -17,7 +17,7 @@ from dolphin._types import Bbox, PathOrStr
 
 gdal.UseExceptions()
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 class MaskConvention(IntEnum):

--- a/src/dolphin/phase_link/_core.py
+++ b/src/dolphin/phase_link/_core.py
@@ -18,7 +18,7 @@ from . import covariance, metrics
 from ._eigenvalues import eigh_largest_stack, eigh_smallest_stack
 from ._ps_filling import fill_ps_pixels
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 DEFAULT_STRIDES = Strides(1, 1)

--- a/src/dolphin/phase_link/_ps_filling.py
+++ b/src/dolphin/phase_link/_ps_filling.py
@@ -10,7 +10,7 @@ from numpy.typing import ArrayLike
 from dolphin._types import Strides
 from dolphin.utils import take_looks
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 def fill_ps_pixels(

--- a/src/dolphin/ps.py
+++ b/src/dolphin/ps.py
@@ -18,7 +18,7 @@ from dolphin.io import EagerLoader, StackReader, repack_raster
 
 gdal.UseExceptions()
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 NODATA_VALUES = {"ps": 255, "amp_dispersion": 0.0, "amp_mean": 0.0}
 

--- a/src/dolphin/shp/__init__.py
+++ b/src/dolphin/shp/__init__.py
@@ -10,7 +10,7 @@ from dolphin.workflows import ShpMethod
 
 from . import _glrt, _ks
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 __all__ = ["estimate_neighbors"]
 

--- a/src/dolphin/shp/_ks.py
+++ b/src/dolphin/shp/_ks.py
@@ -14,7 +14,7 @@ from dolphin.utils import _get_slices, compute_out_shape
 
 from ._common import remove_unconnected
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 _get_slices = numba.njit(_get_slices)

--- a/src/dolphin/similarity.py
+++ b/src/dolphin/similarity.py
@@ -15,7 +15,7 @@ from numpy.typing import ArrayLike
 
 from dolphin._types import PathOrStr
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 @numba.njit(nogil=True)

--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -19,7 +19,7 @@ from dolphin.io import DEFAULT_DATETIME_FORMAT
 from dolphin.utils import format_dates
 
 DateOrDatetime = datetime | date
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 class CompressedSlcPlan(str, Enum):

--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -22,7 +22,7 @@ from dolphin import io, utils
 from dolphin._types import Bbox, Filename
 from dolphin.io import DEFAULT_DATETIME_FORMAT
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 def merge_by_date(

--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -22,7 +22,7 @@ from dolphin.utils import flatten, format_dates, full_suffix, get_nearest_date_i
 
 T = TypeVar("T")
 DateOrDatetime = datetime | date
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 __all__ = ["run"]
 

--- a/src/dolphin/unwrap/_post_process.py
+++ b/src/dolphin/unwrap/_post_process.py
@@ -10,7 +10,7 @@ from scipy.interpolate import NearestNDInterpolator
 
 TWOPI = 2 * np.pi
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 @njit(nogil=True)

--- a/src/dolphin/unwrap/_snaphu_py.py
+++ b/src/dolphin/unwrap/_snaphu_py.py
@@ -12,7 +12,7 @@ from dolphin.utils import full_suffix
 from ._constants import CONNCOMP_SUFFIX, DEFAULT_CCL_NODATA, DEFAULT_UNW_NODATA
 from ._utils import _zero_from_mask
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 def unwrap_snaphu_py(

--- a/src/dolphin/unwrap/_tophu.py
+++ b/src/dolphin/unwrap/_tophu.py
@@ -14,7 +14,7 @@ from dolphin.workflows import UnwrapMethod
 from ._constants import CONNCOMP_SUFFIX, DEFAULT_CCL_NODATA, DEFAULT_UNW_NODATA
 from ._utils import _redirect_unwrapping_log, _zero_from_mask
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 def multiscale_unwrap(

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -31,7 +31,7 @@ from ._unwrap_3d import unwrap_spurt
 from ._utils import create_combined_mask, set_nodata_values
 from ._whirlwind import unwrap_whirlwind
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 __all__ = ["run", "unwrap"]
 

--- a/src/dolphin/unwrap/_unwrap_3d.py
+++ b/src/dolphin/unwrap/_unwrap_3d.py
@@ -21,7 +21,7 @@ from dolphin.workflows.config import SpurtOptions
 from ._constants import CONNCOMP_SUFFIX, DEFAULT_CCL_NODATA, UNW_SUFFIX
 from ._post_process import interpolate_masked_gaps
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 DEFAULT_OPTIONS = SpurtOptions()
 

--- a/src/dolphin/unwrap/_utils.py
+++ b/src/dolphin/unwrap/_utils.py
@@ -9,7 +9,7 @@ import rasterio as rio
 from dolphin import io
 from dolphin._types import Filename
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 def create_combined_mask(

--- a/src/dolphin/unwrap/_whirlwind.py
+++ b/src/dolphin/unwrap/_whirlwind.py
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 def unwrap_whirlwind(

--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -22,7 +22,7 @@ from dolphin._types import Bbox, Filename, P, Strides, T
 DateOrDatetime = Union[datetime.date, datetime.datetime]
 
 gdal.UseExceptions()
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 def numpy_to_gdal_type(np_dtype: DTypeLike) -> int:
@@ -46,6 +46,7 @@ def numpy_to_gdal_type(np_dtype: DTypeLike) -> int:
 
     """
     np_dtype = np.dtype(np_dtype)
+    logger.info("huh")
 
     if np.issubdtype(bool, np_dtype):
         return gdalconst.GDT_Byte

--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -46,7 +46,6 @@ def numpy_to_gdal_type(np_dtype: DTypeLike) -> int:
 
     """
     np_dtype = np.dtype(np_dtype)
-    logger.info("huh")
 
     if np.issubdtype(bool, np_dtype):
         return gdalconst.GDT_Byte

--- a/src/dolphin/workflows/_utils.py
+++ b/src/dolphin/workflows/_utils.py
@@ -13,7 +13,7 @@ from dolphin._types import Filename
 
 from .config import DisplacementWorkflow
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 def _create_burst_cfg(

--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -23,7 +23,7 @@ from dolphin.stack import CompressedSlcPlan
 from ._enums import ShpMethod
 from ._yaml_model import YamlModel
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 __all__ = [
     "HalfWindow",

--- a/src/dolphin/workflows/config/_displacement.py
+++ b/src/dolphin/workflows/config/_displacement.py
@@ -34,7 +34,7 @@ __all__ = [
     "DisplacementWorkflow",
 ]
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 # Add a class for troposphere, ionosphere corrections, with geometry files and DEM

--- a/src/dolphin/workflows/config/_ps.py
+++ b/src/dolphin/workflows/config/_ps.py
@@ -18,7 +18,7 @@ __all__ = [
     "PsWorkflow",
 ]
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 class PsWorkflow(WorkflowBase):

--- a/src/dolphin/workflows/config/_unwrap_options.py
+++ b/src/dolphin/workflows/config/_unwrap_options.py
@@ -13,7 +13,7 @@ from pydantic import (
 
 from ._enums import UnwrapMethod
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 __all__ = [
     "PreprocessOptions",

--- a/src/dolphin/workflows/config/_unwrapping.py
+++ b/src/dolphin/workflows/config/_unwrapping.py
@@ -19,7 +19,7 @@ __all__ = [
     "UnwrappingWorkflow",
 ]
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 class UnwrappingWorkflow(WorkflowBase):

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -21,7 +21,7 @@ from . import stitching_bursts, unwrapping, wrapped_phase
 from ._utils import _create_burst_cfg, _remove_dir_if_empty, parse_ionosphere_files
 from .config import DisplacementWorkflow
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 @dataclass
@@ -64,8 +64,7 @@ def run(
     if cfg.log_file is None:
         cfg.log_file = cfg.work_directory / "dolphin.log"
     # Set the logging level for all `dolphin.` modules
-    for logger_name in ["dolphin", "spurt"]:
-        setup_logging(logger_name=logger_name, debug=debug, filename=cfg.log_file)
+    setup_logging(logger_name="dolphin", debug=debug, filename=cfg.log_file)
     # TODO: need to pass the cfg filename for the logger
     logger.debug(cfg.model_dump())
 

--- a/src/dolphin/workflows/ps.py
+++ b/src/dolphin/workflows/ps.py
@@ -8,21 +8,20 @@ import opera_utils
 
 import dolphin.ps
 from dolphin import __version__, masking
-from dolphin._log import log_runtime, setup_logging
+from dolphin._log import log_runtime
 from dolphin.io import VRTStack
 from dolphin.utils import get_max_memory_usage
 from dolphin.workflows.wrapped_phase import _get_mask
 
 from .config import DisplacementWorkflow, PsWorkflow
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 @log_runtime
 def run(
     cfg: PsWorkflow | DisplacementWorkflow,
     compute_looked: bool = False,
-    debug: bool = False,
 ) -> list[Path]:
     """Run the displacement workflow on a stack of SLCs.
 
@@ -38,7 +37,6 @@ def run(
 
     """
     # Set the logging level for all `dolphin.` modules
-    setup_logging(debug=debug, filename=cfg.log_file)
     logger.debug(pformat(cfg.model_dump()))
 
     output_file_list = [

--- a/src/dolphin/workflows/sequential.py
+++ b/src/dolphin/workflows/sequential.py
@@ -24,7 +24,7 @@ from dolphin.stack import CompressedSlcPlan, MiniStackPlanner
 from .config import ShpMethod
 from .single import run_wrapped_phase_single
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 __all__ = ["run_wrapped_phase_sequential"]
 

--- a/src/dolphin/workflows/single.py
+++ b/src/dolphin/workflows/single.py
@@ -22,7 +22,7 @@ from dolphin.stack import MiniStackInfo
 
 from .config import ShpMethod
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 __all__ = ["run_wrapped_phase_single"]
 

--- a/src/dolphin/workflows/stitching_bursts.py
+++ b/src/dolphin/workflows/stitching_bursts.py
@@ -16,7 +16,7 @@ from dolphin.io._utils import repack_raster
 
 from .config import OutputOptions
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 @dataclass

--- a/src/dolphin/workflows/unwrapping.py
+++ b/src/dolphin/workflows/unwrapping.py
@@ -14,7 +14,7 @@ from dolphin._types import PathOrStr
 
 from .config import UnwrapOptions
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 @log_runtime

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -17,7 +17,7 @@ from dolphin.workflows import UnwrapMethod
 from . import InterferogramNetwork, sequential
 from .config import DisplacementWorkflow
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("dolphin")
 
 
 @log_runtime

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,6 @@
 asv
 black
 boto3
-flake8
 moto[server,s3]
 pooch
 pre-commit


### PR DESCRIPTION
The logger right now is slightly broken.

- We have been using `__name__` so that we get a logger hierarchy like `dolphin.utils`
- The `setup_logging` works on the `dolphin` logger
- We setup stdout and file handlers on the `dolphin` logger. We set [propagate](https://docs.python.org/3/library/logging.html#logging.Logger.propagate) to True
- Propagation only happens for `"dolphin"`, not `dolphin.utils`, etc

This is why many logging messages don't make it into the output file. I don't see a good way to set up all of the loggers with propagate. It seems much easier just to always use the `dolphin` logger