### PR TITLE
Add `utils.grow_nodata_region` to remove bad borders from `shp_counts.tif`

### DIFF
--- a/src/dolphin/io/_core.py
+++ b/src/dolphin/io/_core.py
@@ -15,7 +15,7 @@ from typing import Any, Mapping, Optional, Sequence, Union
 
 import h5py
 import numpy as np
-from numpy.typing import ArrayLike, DTypeLike
+from numpy.typing import ArrayLike, DTypeLike, NDArray
 from osgeo import gdal
 from pyproj import CRS
 
@@ -688,7 +688,7 @@ def write_arr(
 
 
 def write_block(
-    cur_block: ArrayLike,
+    cur_block: NDArray,
     filename: Filename,
     row_start: int,
     col_start: int,
@@ -738,7 +738,7 @@ def write_block(
 
 
 def _write_gdal(
-    cur_block: ArrayLike,
+    cur_block: NDArray,
     filename: Filename,
     row_start: int,
     col_start: int,
@@ -761,7 +761,7 @@ def _write_gdal(
 
 
 def _write_hdf5(
-    cur_block: ArrayLike,
+    cur_block: NDArray,
     filename: Filename,
     row_start: int,
     col_start: int,

--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -755,13 +755,14 @@ def erode_edge_pixels(
     """
     from scipy import ndimage
 
+    arr = np.asarray(arr)
     if arr.ndim != 2:
         raise ValueError("Input array must be 2D.")
 
-    mask = np.asarray(arr) == nodata if not np.isnan(nodata) else np.isnan(arr)
+    mask = arr == nodata if not np.isnan(nodata) else np.isnan(arr)
     mask_expanded = ndimage.binary_dilation(
         mask, structure=np.ones((1 + 2 * n_pixels, 1 + 2 * n_pixels))
     )
-    out = np.asarray(arr).copy() if copy else np.asarray(arr)
+    out = arr.copy() if copy else arr
     out[mask_expanded] = nodata
     return out

--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -720,13 +720,15 @@ def get_nearest_date_idx(
     return nearest_idx
 
 
-def erode_edge_pixels(
+def grow_nodata_region(
     arr: ArrayLike, nodata: float, n_pixels: int = 1, copy: bool = True
 ) -> np.ndarray:
-    """Erode `n_pixels` from the border of a 2D array by updating its mask.
+    """Grow the `nodata` region of `arr` by  `n_pixels`.
 
-    This function creates a mask from the `nodata` value, then extends the mask
-    inward from the boundaries by `n_pixels`.
+    This function erodes valid pixels in `arr` by making a mask from the `nodata` value
+    and then extends the mask inward by `n_pixels`.
+
+    If `arr` has no `nodata` value, the function returns `arr` unchanged.
 
     Parameters
     ----------
@@ -736,7 +738,7 @@ def erode_edge_pixels(
         The value in `arr` that represents nodata.
     n_pixels : int, optional
         Number of pixels to erode from the border
-        Default is 2.
+        Default is 1.
     copy : bool, optional
         Whether to copy the input data before eroding.
         Default is True (no in-place modification is made).
@@ -760,6 +762,7 @@ def erode_edge_pixels(
         raise ValueError("Input array must be 2D.")
 
     mask = arr == nodata if not np.isnan(nodata) else np.isnan(arr)
+    # "growing" the invalid (nodata) area equivalently "erodes" the valid data
     mask_expanded = ndimage.binary_dilation(
         mask, structure=np.ones((1 + 2 * n_pixels, 1 + 2 * n_pixels))
     )

--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -718,3 +718,50 @@ def get_nearest_date_idx(
     )
 
     return nearest_idx
+
+
+def erode_edge_pixels(
+    arr: ArrayLike, nodata: float, n_pixels: int = 1, copy: bool = True
+) -> np.ndarray:
+    """Erode `n_pixels` from the border of a 2D array by updating its mask.
+
+    This function creates a mask from the `nodata` value, then extends the mask
+    inward from the boundaries by `n_pixels`.
+
+    Parameters
+    ----------
+    arr : numpy.ndarray
+        Input array containing the data and mask to be eroded
+    nodata : float
+        The value in `arr` that represents nodata.
+    n_pixels : int, optional
+        Number of pixels to erode from the border
+        Default is 2.
+    copy : bool, optional
+        Whether to copy the input data before eroding.
+        Default is True (no in-place modification is made).
+
+    Returns
+    -------
+    numpy.ndarray
+        Array with the same data, eroded by `n_pixels`.
+        If `copy` is False, the input array is modified in place.
+
+    Raises
+    ------
+    ValueError
+        If `arr` is not 2D.
+
+    """
+    from scipy import ndimage
+
+    if arr.ndim != 2:
+        raise ValueError("Input array must be 2D.")
+
+    mask = np.asarray(arr) == nodata if not np.isnan(nodata) else np.isnan(arr)
+    mask_expanded = ndimage.binary_dilation(
+        mask, structure=np.ones((1 + 2 * n_pixels, 1 + 2 * n_pixels))
+    )
+    out = np.asarray(arr).copy() if copy else np.asarray(arr)
+    out[mask_expanded] = nodata
+    return out

--- a/src/dolphin/workflows/single.py
+++ b/src/dolphin/workflows/single.py
@@ -14,11 +14,12 @@ from tqdm.auto import tqdm
 from dolphin import io, shp, similarity
 from dolphin._decorators import atomic_output
 from dolphin._types import Filename, HalfWindow, Strides
-from dolphin.io import EagerLoader, StridedBlockManager, VRTStack
+from dolphin.io import BlockIndices, EagerLoader, StridedBlockManager, VRTStack
 from dolphin.masking import load_mask_as_numpy
 from dolphin.phase_link import PhaseLinkRuntimeError, compress, run_phase_linking
 from dolphin.ps import calc_ps_block
 from dolphin.stack import MiniStackInfo
+from dolphin.utils import erode_edge_pixels
 
 from .config import ShpMethod
 
@@ -118,24 +119,33 @@ def run_wrapped_phase_single(
 
     # Use the real-SLC date range for output file naming
     start_end = ministack.real_slc_date_range_str
-    output_files: list[OutputFile] = [
+    output_files: dict[str, OutputFile] = {
         # The compressed SLC does not used strides, but has extra band for dispersion
-        OutputFile(output_folder / comp_slc_info.filename, np.complex64, nbands=2),
+        "compressed_slc": OutputFile(
+            output_folder / comp_slc_info.filename, np.complex64, nbands=2
+        ),
         # but all the rest do:
-        OutputFile(
+        "temporal_coherence": OutputFile(
             output_folder / f"temporal_coherence_{start_end}.tif", np.float32, strides
         ),
-        OutputFile(output_folder / f"shp_counts_{start_end}.tif", np.uint16, strides),
-        OutputFile(output_folder / f"eigenvalues_{start_end}.tif", np.float32, strides),
-        OutputFile(
+        "shp_counts": OutputFile(
+            output_folder / f"shp_counts_{start_end}.tif", np.uint16, strides
+        ),
+        "eigenvalues": OutputFile(
+            output_folder / f"eigenvalues_{start_end}.tif", np.float32, strides
+        ),
+        "estimator": OutputFile(
             output_folder / f"estimator_{start_end}.tif",
             np.int8,
             strides,
             nodata=255,
         ),
-        OutputFile(output_folder / f"avg_coh_{start_end}.tif", np.uint16, strides),
-    ]
-    for op in output_files:
+        "avg_coh": OutputFile(
+            output_folder / f"avg_coh_{start_end}.tif", np.uint16, strides
+        ),
+    }
+
+    for op in output_files.values():
         io.write_arr(
             arr=None,
             like_filename=vrt_stack.outfile,
@@ -156,7 +166,9 @@ def run_wrapped_phase_single(
     # Set up the background loader
     loader = EagerLoader(reader=vrt_stack, block_shape=block_shape)
     # Queue all input slices, skip ones that are all nodata
-    blocks = []
+    blocks: list[
+        tuple[BlockIndices, BlockIndices, BlockIndices, BlockIndices, BlockIndices]
+    ] = []
     # Queue all input slices, skip ones that are all nodata
     for b in block_manager.iter_blocks():
         in_rows, in_cols = b[2]
@@ -260,7 +272,7 @@ def run_wrapped_phase_single(
         # Save the compressed SLC block
         writer.queue_write(
             cur_comp_slc,
-            output_files[0].filename,
+            output_files["compressed_slc"].filename,
             in_no_pad_rows.start,
             in_no_pad_cols.start,
             band=1,
@@ -268,23 +280,24 @@ def run_wrapped_phase_single(
         # Save the amplitude dispersion of the real SLC data
         writer.queue_write(
             cur_amp_dispersion,
-            output_files[0].filename,
+            output_files["compressed_slc"].filename,
             in_no_pad_rows.start,
             in_no_pad_cols.start,
             band=2,
         )
 
         # All other outputs are strided (smaller in size)
-        out_datas: list[np.ndarray | None] = [
-            pl_output.temp_coh,
-            pl_output.shp_counts,
-            pl_output.eigenvalues,
-            pl_output.estimator,
-            pl_output.avg_coh,
-        ]
-        for data, output_file in zip(out_datas, output_files[1:]):
+        out_datas: dict[str, np.ndarray | None] = {
+            "temporal_coherence": pl_output.temp_coh,
+            "shp_counts": pl_output.shp_counts,
+            "eigenvalues": pl_output.eigenvalues,
+            "estimator": pl_output.estimator,
+            "avg_coh": pl_output.avg_coh,
+        }
+        for key, data in out_datas.items():
             if data is None:  # May choose to skip some outputs, e.g. "avg_coh"
                 continue
+            output_file = output_files[key]
             trimmed_data = data[out_trim_rows, out_trim_cols]
             writer.queue_write(
                 trimmed_data,
@@ -302,6 +315,12 @@ def run_wrapped_phase_single(
     logger.info("Repacking for more compression")
     io.repack_rasters(phase_linked_slc_files, keep_bits=12)
 
+    logger.info("Eroding border of SHP rasters")
+    shp_file = output_files["shp_counts"]
+    shp_data = io.load_gdal(shp_file.filename)
+    erode_edge_pixels(shp_data, nodata=shp_file.nodata, n_pixels=2, copy=False)
+    io.write_block(shp_data, shp_file.filename, row_start=0, col_start=0)
+
     logger.info("Creating similarity raster on outputs")
     similarity.create_similarities(
         phase_linked_slc_files,
@@ -312,7 +331,7 @@ def run_wrapped_phase_single(
         block_shape=block_shape,
     )
 
-    written_comp_slc = output_files[0]
+    written_comp_slc = output_files["compressed_slc"]
     ccslc_info = ministack.get_compressed_slc_info()
     ccslc_info.write_metadata(output_file=written_comp_slc.filename)
     # TODO: Does it make sense to return anything from this?

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 from dolphin import utils
 
@@ -90,3 +91,79 @@ def test_upsample_nearest():
     assert upsampled3d.shape == (3, 4, 4)
     for img in upsampled3d:
         npt.assert_array_equal(img, upsampled)
+
+
+class TestErodeBorderPixels:
+    @pytest.mark.parametrize("nodata", [0, -9999.0, np.nan])
+    def test_erode_edge_pixels_basic_rectangle(self, nodata):
+        """Test basic rectangular data with nodata border."""
+        arr = np.full((5, 5), nodata)
+        # rows/cols 1,2,3 are valid
+        arr[1:4, 1:4] = 1
+        # After eroding 1, only the middle is left
+        expected = np.full((5, 5), nodata)
+        expected[2, 2] = 1
+
+        result = utils.erode_edge_pixels(arr, nodata=nodata, n_pixels=1)
+        npt.assert_array_equal(result, expected)
+
+    def test_erode_edge_pixels_diagonal(self):
+        """Test diagonal line of data."""
+        arr = np.full((6, 6), -9999.0)
+        # Create diagonal line of data
+        np.fill_diagonal(arr, 100)
+        result = utils.erode_edge_pixels(arr, nodata=-9999.0, n_pixels=1)
+
+        # Everything should be eroded due to 9-connectivity
+        expected = np.full((6, 6), -9999.0)
+        npt.assert_array_equal(result, expected)
+
+    def test_erode_edge_pixels_irregular_shape(self):
+        """Test irregular L-shaped data pattern."""
+        arr = np.full((5, 5), 0)
+        # Create L-shaped pattern
+        arr[1:4, 1] = 1  # vertical line
+        arr[3, 1:4] = 1  # horizontal line
+
+        result = utils.erode_edge_pixels(arr, nodata=0, n_pixels=1)
+        # After erosion, both single-pixel lines are gone
+        expected = np.full((5, 5), 0)
+        npt.assert_array_equal(result, expected)
+
+    def test_erode_edge_pixels_no_copy(self):
+        """Test in-place modification when copy=False."""
+        arr = np.full((4, 4), 0)
+        arr[1:3, 1:3] = 1
+        original_arr = arr.copy()
+
+        result = utils.erode_edge_pixels(arr, nodata=0, n_pixels=1, copy=False)
+        assert result is arr  # Should return same object
+        assert not np.array_equal(arr, original_arr)  # Should be modified
+
+    def test_erode_edge_pixels_larger_window(self):
+        """Test erosion with larger window size."""
+        arr = np.full((7, 7), 0)
+        arr[1:6, 1:6] = 1
+
+        result = utils.erode_edge_pixels(arr, nodata=0, n_pixels=2)
+        expected = np.full((7, 7), 0)
+        expected[3, 3] = 1
+        npt.assert_array_equal(result, expected)
+
+    def test_erode_edge_pixels_all_nodata(self):
+        """Test array with all nodata values."""
+        arr = np.full((4, 4), 0)
+        result = utils.erode_edge_pixels(arr, nodata=0, n_pixels=1)
+        npt.assert_array_equal(result, arr)
+
+    @pytest.mark.parametrize(
+        "invalid_input",
+        [
+            np.array([1, 2, 3]),  # 1D array
+            np.array([[[1]]]),  # 3D array
+        ],
+    )
+    def test_erode_edge_pixels_invalid_dimensions(self, invalid_input):
+        """Test that function raises error for non-2D arrays."""
+        with pytest.raises(ValueError):
+            utils.erode_edge_pixels(invalid_input, nodata=-9999.0)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
- Adds `utils.grow_nodata_region`
- Runs function during phase linking workflow to remove bad border pixels from SHP rasters.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

Fixes #547 

<img width="644" alt="image" src="https://github.com/user-attachments/assets/8fcb10e0-c18a-4f37-bfc1-7178ffb79c02" />


## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review
