### PR TITLE
Create `nonzero_conncomp_count_` outputs after timeseries inversion

### DIFF
--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -40,6 +40,7 @@ class OutputPaths:
     conncomp_paths: list[Path] | None
     timeseries_paths: list[Path] | None
     timeseries_residual_paths: list[Path] | None
+    nonzero_conncomp_count_paths: list[Path] | None
     tropospheric_corrections: list[Path] | None
     ionospheric_corrections: list[Path] | None
     reference_point: ReferencePoint | None
@@ -225,6 +226,7 @@ def run(
             conncomp_paths=None,
             timeseries_paths=None,
             timeseries_residual_paths=None,
+            nonzero_conncomp_count_paths=None,
             tropospheric_corrections=None,
             ionospheric_corrections=None,
             reference_point=None,
@@ -254,7 +256,12 @@ def run(
     if ts_opts.run_inversion or ts_opts.run_velocity:
         # the output of run_timeseries is not currently used so pre-commit removes it
         # let's add back if we need it
-        timeseries_paths, timeseries_residual_paths, reference_point = timeseries.run(
+        (
+            timeseries_paths,
+            timeseries_residual_paths,
+            nonzero_conncomp_count_paths,
+            reference_point,
+        ) = timeseries.run(
             unwrapped_paths=unwrapped_paths,
             conncomp_paths=conncomp_paths,
             corr_paths=stitched_paths.interferometric_corr_paths,
@@ -278,6 +285,7 @@ def run(
     else:
         timeseries_paths = None
         timeseries_residual_paths = None
+        nonzero_conncomp_count_paths = None
         reference_point = None
 
     # ##############################################
@@ -379,6 +387,7 @@ def run(
         conncomp_paths=conncomp_paths,
         timeseries_paths=timeseries_paths,
         timeseries_residual_paths=timeseries_residual_paths,
+        nonzero_conncomp_count_paths=nonzero_conncomp_count_paths,
         tropospheric_corrections=tropo_paths,
         ionospheric_corrections=iono_paths,
         reference_point=reference_point,


### PR DESCRIPTION
This PR runs the function from #485 during the normal displacement workflow when an inversion happened.

TBD: Analysis whether this is worth it to include, or whether the conncomps are too smeared out from using the sliding-window correlation.