### PR TITLE
Remove single-burst special case, keep phase linking results to `phas… e487ce2  …e_linking/`

### DIFF
--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -77,7 +77,7 @@ def run(
         if "Could not parse burst id" not in str(e):
             raise
         # Otherwise, we have SLC files which are not OPERA burst files
-        grouped_slc_files = {"": cfg.cslc_file_list}
+        grouped_slc_files = {"phase_linking": cfg.cslc_file_list}
 
     if cfg.amplitude_dispersion_files:
         grouped_amp_dispersion_files = group_by_burst(cfg.amplitude_dispersion_files)
@@ -97,33 +97,26 @@ def run(
     # ######################################
     # 1. Burst-wise Wrapped phase estimation
     # ######################################
-    if len(grouped_slc_files) > 1:
-        logger.info(f"Found SLC files from {len(grouped_slc_files)} bursts")
-        wrapped_phase_cfgs = [
-            (
-                burst,  # Include the burst for logging purposes
-                _create_burst_cfg(
-                    cfg,
-                    burst,
-                    grouped_slc_files,
-                    grouped_amp_mean_files,
-                    grouped_amp_dispersion_files,
-                    grouped_layover_shadow_mask_files,
-                ),
-            )
-            for burst in grouped_slc_files
-        ]
-        for _, burst_cfg in wrapped_phase_cfgs:
-            burst_cfg.create_dir_tree()
-        # Remove the mid-level directories which will be empty due to re-grouping
-        _remove_dir_if_empty(cfg.phase_linking._directory)
-        _remove_dir_if_empty(cfg.ps_options._directory)
-
-    else:
-        # grab the only key (either a burst, or "") and use that
-        cfg.create_dir_tree()
-        b = next(iter(grouped_slc_files.keys()))
-        wrapped_phase_cfgs = [(b, cfg)]
+    logger.info(f"Found SLC files from {len(grouped_slc_files)} bursts")
+    wrapped_phase_cfgs = [
+        (
+            burst,  # Include the burst for logging purposes
+            _create_burst_cfg(
+                cfg,
+                burst,
+                grouped_slc_files,
+                grouped_amp_mean_files,
+                grouped_amp_dispersion_files,
+                grouped_layover_shadow_mask_files,
+            ),
+        )
+        for burst in grouped_slc_files
+    ]
+    for _, burst_cfg in wrapped_phase_cfgs:
+        burst_cfg.create_dir_tree()
+    # Remove the mid-level directories which will be empty due to re-grouping
+    _remove_dir_if_empty(cfg.phase_linking._directory)
+    _remove_dir_if_empty(cfg.ps_options._directory)
 
     ifg_file_list: list[Path] = []
     temp_coh_file_list: list[Path] = []

--- a/tests/test_io_writers.py
+++ b/tests/test_io_writers.py
@@ -174,5 +174,5 @@ class TestBackgroundStackWriter:
         w5[:, rows, cols] = data2
         w5.close()
         written = load_gdal(output_file_list[0], rows=rows, cols=cols)
-        # Check for the samll floating point differences
+        # Check for the small floating point differences
         assert np.abs(written - data).max() > 1e-6

--- a/tests/test_workflows_displacement.py
+++ b/tests/test_workflows_displacement.py
@@ -144,7 +144,7 @@ def test_separate_workflow_runs(slc_file_list, tmp_path):
     assert len(file_batches) == 3
     assert all(len(b) == 10 for b in file_batches)
     run_displacement_stack(p1, file_batches[0])
-    new_comp_slcs1 = sorted((p1 / "linked_phase").glob("compressed_*"))
+    new_comp_slcs1 = sorted((p1 / "phase_linking/linked_phase").glob("compressed_*"))
     assert len(new_comp_slcs1) == 1
     ifgs1 = sorted((p1 / "interferograms").glob("*.int.tif"))
     assert len(ifgs1) == 9
@@ -152,7 +152,7 @@ def test_separate_workflow_runs(slc_file_list, tmp_path):
     p2 = tmp_path / Path("second")
     files2 = new_comp_slcs1 + file_batches[1]
     run_displacement_stack(p2, files2)
-    new_comp_slcs2 = sorted((p2 / "linked_phase").glob("compressed_*"))
+    new_comp_slcs2 = sorted((p2 / "phase_linking/linked_phase").glob("compressed_*"))
     assert len(new_comp_slcs2) == 1
     ifgs2 = sorted((p2 / "interferograms").glob("*.int.tif"))
     assert len(ifgs2) == 10


### PR DESCRIPTION
Currently the multi-burst outputs have one directory per burst ID, while the single-burst is a special case that moves those contents to the top level `work_directory`.
This is unnecessary, and has led to problems such as https://github.com/opera-adt/disp-s1/issues/296

This always places the phase linking results in one directory up from `work`, naming it `phase_linking` in case it's a general non-OPERA swath.