### PR TITLE
Parallelize phase linking for single-swath case in `single.py`

### DIFF
--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -265,7 +265,9 @@ class WorkerSettings(BaseModel, extra="forbid"):
         ge=1,
         description=(
             "If processing separate spatial bursts, number of bursts to run in parallel"
-            " for wrapped-phase-estimation."
+            " for wrapped-phase-estimation. For large, single-swath SLC stacks (e.g."
+            " UAVSAR, NISAR), this sets the number of chunks processed in parallel"
+            " during phase linking."
         ),
     )
     block_shape: tuple[int, int] = Field(

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -137,15 +137,16 @@ def run(
     # Now for each burst, run the wrapped phase estimation
     # Try running several bursts in parallel...
     # Use the Dummy one if not going parallel, as debugging is much simpler
-    num_parallel = min(cfg.worker_settings.n_parallel_bursts, len(grouped_slc_files))
+    num_workers = cfg.worker_settings.n_parallel_bursts
+    num_parallel = min(num_workers, len(grouped_slc_files))
     Executor = (
         ProcessPoolExecutor if num_parallel > 1 else utils.DummyProcessPoolExecutor
     )
-    mw = cfg.worker_settings.n_parallel_bursts
+    workers_per_burst = num_workers // num_parallel
     ctx = mp.get_context("spawn")
     tqdm.set_lock(ctx.RLock())
     with Executor(
-        max_workers=mw,
+        max_workers=num_workers,
         mp_context=ctx,
         initializer=tqdm.set_lock,
         initargs=(tqdm.get_lock(),),
@@ -155,6 +156,7 @@ def run(
                 wrapped_phase.run,
                 burst_cfg,
                 debug=debug,
+                max_workers=workers_per_burst,
                 tqdm_kwargs={
                     "position": i,
                 },

--- a/src/dolphin/workflows/sequential.py
+++ b/src/dolphin/workflows/sequential.py
@@ -54,6 +54,7 @@ def run_wrapped_phase_sequential(
     cslc_date_fmt: str = "%Y%m%d",
     block_shape: tuple[int, int] = (512, 512),
     baseline_lag: Optional[int] = None,
+    max_workers: int = 1,
     **tqdm_kwargs,
 ) -> tuple[list[Path], list[Path], Path, Path, Path]:
     """Estimate wrapped phase using batches of ministacks."""
@@ -135,6 +136,7 @@ def run_wrapped_phase_sequential(
                 similarity_nearest_n=similarity_nearest_n,
                 block_shape=block_shape,
                 baseline_lag=baseline_lag,
+                max_workers=max_workers,
                 **tqdm_kwargs,
             )
 

--- a/src/dolphin/workflows/single.py
+++ b/src/dolphin/workflows/single.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -19,7 +21,7 @@ from dolphin.masking import load_mask_as_numpy
 from dolphin.phase_link import PhaseLinkRuntimeError, compress, run_phase_linking
 from dolphin.ps import calc_ps_block
 from dolphin.stack import MiniStackInfo
-from dolphin.utils import grow_nodata_region
+from dolphin.utils import DummyProcessPoolExecutor, grow_nodata_region
 
 from .config import ShpMethod
 
@@ -58,6 +60,7 @@ def run_wrapped_phase_single(
     similarity_nearest_n: int | None = None,
     block_shape: tuple[int, int] = (512, 512),
     baseline_lag: Optional[int] = None,
+    num_workers: int = 4,
     **tqdm_kwargs,
 ):
     """Estimate wrapped phase for one ministack.
@@ -86,7 +89,6 @@ def run_wrapped_phase_single(
     nodata_mask = _get_nodata_mask(mask_file, nrows, ncols)
     ps_mask = _get_ps_mask(ps_mask_file, nrows, ncols)
     amp_mean, amp_variance = _get_amp_mean_variance(amp_mean_file, amp_dispersion_file)
-    amp_stack: Optional[np.ndarray] = None
 
     xhalf, yhalf = half_window["x"], half_window["y"]
 
@@ -175,29 +177,38 @@ def run_wrapped_phase_single(
         # nodata_mask is numpy convention: True for bad (masked).
         if nodata_mask[in_rows, in_cols].all():
             continue
-        loader.queue_read(in_rows, in_cols)
+        # loader.queue_read(in_rows, in_cols)
         blocks.append(b)
+    ###########################
+    from threading import Lock
 
-    logger.info(f"Iterating over {block_shape} blocks, {len(blocks)} total")
-    for (
-        (out_rows, out_cols),
-        (out_trim_rows, out_trim_cols),
-        (in_rows, in_cols),
-        (in_no_pad_rows, in_no_pad_cols),
-        (in_trim_rows, in_trim_cols),
-    ) in tqdm(blocks, **tqdm_kwargs):
-        logger.debug(f"{out_rows = }, {out_cols = }, {in_rows = }, {in_no_pad_rows = }")
+    write_lock = Lock()
+    read_lock = Lock()
 
-        cur_data, (read_rows, read_cols) = loader.get_data()
+    Executor = ThreadPoolExecutor if num_workers > 1 else DummyProcessPoolExecutor
+    pbar = tqdm(total=len(blocks), **tqdm_kwargs)
+
+    def _process_block(
+        block: tuple[
+            BlockIndices, BlockIndices, BlockIndices, BlockIndices, BlockIndices
+        ],
+    ):
+        (
+            (out_rows, out_cols),
+            (out_trim_rows, out_trim_cols),
+            (in_rows, in_cols),
+            (in_no_pad_rows, in_no_pad_cols),
+            (in_trim_rows, in_trim_cols),
+        ) = block
+        with read_lock:
+            cur_data, _ = loader.read(in_rows, in_cols)
         if np.all(cur_data == 0) or np.isnan(cur_data).all():
-            continue
-        assert read_rows == in_rows and read_cols == in_cols
+            return block, None, None, None
 
         cur_data = cur_data.astype(np.complex64)
 
-        if shp_method == "ks":
-            # Only actually compute if we need this one
-            amp_stack = np.abs(cur_data)
+        # Only actually compute if we need this one
+        amp_stack = np.abs(cur_data) if shp_method == "ks" else None
 
         # Compute the neighbor_arrays for this block
         neighbor_arrays = shp.estimate_neighbors(
@@ -236,7 +247,7 @@ def run_wrapped_phase_single(
                 logger.debug(msg)
             else:
                 logger.warning(msg)
-            continue
+            return block, None, None, None
 
         # Fill in the nan values with 0
         np.nan_to_num(pl_output.cpx_phase, copy=False)
@@ -247,12 +258,6 @@ def run_wrapped_phase_single(
         assert len(pl_output.cpx_phase[first_real_slc_idx:]) == len(
             phase_linked_slc_files
         )
-
-        for img, f in zip(
-            pl_output.cpx_phase[first_real_slc_idx:, out_trim_rows, out_trim_cols],
-            phase_linked_slc_files,
-        ):
-            writer.queue_write(img, f, out_rows.start, out_cols.start)
 
         # Compress the ministack using only the non-compressed SLCs
         # Get the mean to set as pixel magnitudes
@@ -267,65 +272,70 @@ def run_wrapped_phase_single(
             reference_idx=ministack.compressed_reference_idx,
         )
 
-        # ### Save results ###
+        with write_lock:
+            logger.info(f"{pl_output.cpx_phase[0].shape, out_rows, out_cols}")
+            # ### Save results ###
+            for img, f in zip(
+                pl_output.cpx_phase[first_real_slc_idx:, out_trim_rows, out_trim_cols],
+                phase_linked_slc_files,
+            ):
+                writer.queue_write(img, f, out_rows.start, out_cols.start)
 
-        # Save the compressed SLC block
-        writer.queue_write(
-            cur_comp_slc,
-            output_files["compressed_slc"].filename,
-            in_no_pad_rows.start,
-            in_no_pad_cols.start,
-            band=1,
-        )
-        # Save the amplitude dispersion of the real SLC data
-        writer.queue_write(
-            cur_amp_dispersion,
-            output_files["compressed_slc"].filename,
-            in_no_pad_rows.start,
-            in_no_pad_cols.start,
-            band=2,
-        )
-
-        # All other outputs are strided (smaller in size)
-        out_datas: dict[str, np.ndarray | None] = {
-            "temporal_coherence": pl_output.temp_coh,
-            "shp_counts": pl_output.shp_counts,
-            "eigenvalues": pl_output.eigenvalues,
-            "estimator": pl_output.estimator,
-            "avg_coh": pl_output.avg_coh,
-        }
-        for key, data in out_datas.items():
-            if data is None:  # May choose to skip some outputs, e.g. "avg_coh"
-                continue
-            output_file = output_files[key]
-            trimmed_data = data[out_trim_rows, out_trim_cols]
-
+            # Save the compressed SLC block
             writer.queue_write(
-                # trimmed_data,
-                # Erode the edge pixels
-                grow_nodata_region(
-                    trimmed_data, nodata=output_file.nodata, n_pixels=2, copy=True
-                ),
-                output_file.filename,
-                out_rows.start,
-                out_cols.start,
+                cur_comp_slc,
+                output_files["compressed_slc"].filename,
+                in_no_pad_rows.start,
+                in_no_pad_cols.start,
+                band=1,
+            )
+            # Save the amplitude dispersion of the real SLC data
+            writer.queue_write(
+                cur_amp_dispersion,
+                output_files["compressed_slc"].filename,
+                in_no_pad_rows.start,
+                in_no_pad_cols.start,
+                band=2,
             )
 
-    loader.notify_finished()
+            # All other outputs are strided (smaller in size)
+            out_datas: dict[str, np.ndarray | None] = {
+                "temporal_coherence": pl_output.temp_coh,
+                "shp_counts": pl_output.shp_counts,
+                "eigenvalues": pl_output.eigenvalues,
+                "estimator": pl_output.estimator,
+                "avg_coh": pl_output.avg_coh,
+            }
+            for key, data in out_datas.items():
+                if data is None:  # May choose to skip some outputs, e.g. "avg_coh"
+                    continue
+                output_file = output_files[key]
+                trimmed_data = data[out_trim_rows, out_trim_cols]
+
+                writer.queue_write(
+                    # trimmed_data,
+                    # Erode the edge pixels
+                    grow_nodata_region(
+                        trimmed_data, nodata=output_file.nodata, n_pixels=2, copy=True
+                    ),
+                    output_file.filename,
+                    out_rows.start,
+                    out_cols.start,
+                )
+            pbar.update()
+
+    with Executor(num_workers) as exc:
+        # Consume all blocks from the `.map` call
+        deque(exc.map(_process_block, blocks))
+
     # Block until all the writers for this ministack have finished
     logger.info(f"Waiting to write {writer.num_queued} blocks of data.")
     writer.notify_finished()
     logger.info(f"Finished ministack of size {vrt_stack.shape}.")
+    loader.notify_finished()
 
     logger.info("Repacking for more compression")
     io.repack_rasters(phase_linked_slc_files, keep_bits=12)
-
-    # logger.info("Eroding border of SHP rasters")
-    # shp_file = output_files["shp_counts"]
-    # shp_data = io.load_gdal(shp_file.filename)
-    # # Eroding in blocks to avoid too-large rasters.
-    # erode_edge_pixels(shp_data, nodata=shp_file.nodata, n_pixels=2, copy=False)
-    # io.write_block(shp_data, shp_file.filename, row_start=0, col_start=0)
 
     logger.info("Creating similarity raster on outputs")
     similarity.create_similarities(

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -22,7 +22,10 @@ logger = logging.getLogger("dolphin")
 
 @log_runtime
 def run(
-    cfg: DisplacementWorkflow, debug: bool = False, tqdm_kwargs=None
+    cfg: DisplacementWorkflow,
+    debug: bool = False,
+    max_workers: int = 1,
+    tqdm_kwargs=None,
 ) -> tuple[list[Path], list[Path], Path, Path, Path, Path, Path]:
     """Run the displacement workflow on a stack of SLCs.
 
@@ -33,6 +36,8 @@ def run(
         for controlling the workflow.
     debug : bool, optional
         Enable debug logging, by default False.
+    max_workers : int, optional
+        Number of workers to use to process blocks during phase linking, by default 1.
     tqdm_kwargs : dict, optional
         dict of arguments to pass to `tqdm` (e.g. `position=n` for n parallel bars)
         See https://tqdm.github.io/docs/tqdm/#tqdm-objects for all options.
@@ -203,6 +208,7 @@ def run(
             similarity_nearest_n=similarity_nearest_n,
             cslc_date_fmt=cfg.input_options.cslc_date_fmt,
             block_shape=cfg.worker_settings.block_shape,
+            max_workers=max_workers,
             **kwargs,
         )
     # Dump the used options for JSON parsing


### PR DESCRIPTION
Improves performance for single burst (large swath, like NISAR) by adding block-level parallelism.

- Uses `ThreadPoolExecutor` since core JAX functions release GIL
- Refactored each block's processing to an inline `_process_block` function
- One tricky bit is the need for `read_lock` and `write_lock` to prevent race conditions on the background readers/writers

Closes #265 


Test case for a synthetic stack, shape `(15, 1997, 2138)`

Main branch: time for phase linking iteration: 51 seconds
```
dolphin run dolphin_config.yaml  114.60s user 8.00s system 203% cpu 1:00.17 total
```

PR Timings

- 1 worker: 55 seconds
```
dolphin run dolphin_config.yaml  112.15s user 7.90s system 192% cpu 1:02.33 total
```

- 3 workers: 24 seconds 
```
dolphin run dolphin_config.yaml  129.69s user 8.51s system 443% cpu 31.148 total
```

- 7 workers: 17 seconds
```
dolphin run dolphin_config.yaml  162.07s user 10.51s system 700% cpu 24.620 total
```

TODO:
- ~~Do we need to change the name of `n_parallel_bursts`? We could just use that for this argument (Answer: keeping the same for API compatibility. Documented this in the config string for `n_parallel_bursts`)~~
- ~~For a case where we pass 2 bursts, but set `n_parallel_bursts=7` (e.g.), should we then process each burst in parallel, and set the `max_workers` in single.py to `7 // 2 = 3` to run 3 blocks in parallel for both bursts?~~ 