### PR TITLE
Remove unused `_utils` helper functions

### DIFF
--- a/src/dolphin/io/_utils.py
+++ b/src/dolphin/io/_utils.py
@@ -95,23 +95,6 @@ def get_gtiff_options(
     return options
 
 
-def _format_for_gdal(options: dict[str, str]) -> list[str]:
-    """Output creation options as a list of -co strings for GDAL.
-
-    Parameters
-    ----------
-    options : dict[str, str]
-        Dict of creation options usable in Rasterio.
-
-    Returns
-    -------
-    list[str]
-        List -co options for GDAL.
-
-    """
-    return [f"{k.upper()}={v}" for k, v in options.items()]
-
-
 def repack_raster(
     raster_path: Path,
     output_dir: Path | None = None,

--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -6,6 +6,7 @@ import logging
 import math
 import subprocess
 import tempfile
+from collections.abc import Mapping
 from datetime import datetime
 from os import fspath
 from pathlib import Path
@@ -133,7 +134,7 @@ def merge_images(
     target_aligned_pixels: bool = True,
     out_bounds: Optional[Bbox] = None,
     out_bounds_epsg: Optional[int] = None,
-    strides: Optional[dict[str, int]] = None,
+    strides: Optional[Mapping[str, int]] = None,
     driver: str = "GTiff",
     out_nodata: Optional[float] = 0,
     out_dtype: Optional[DTypeLike] = None,
@@ -293,7 +294,7 @@ def merge_images(
 
 def get_downsampled_vrts(
     filenames: Sequence[Filename],
-    strides: dict[str, int],
+    strides: Mapping[str, int],
     dirname: Filename,
 ) -> list[Path]:
     """Create downsampled VRTs from a list of files.

--- a/src/dolphin/unwrap/_tophu.py
+++ b/src/dolphin/unwrap/_tophu.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from os import fspath
 from pathlib import Path
 
 import numpy as np
@@ -12,7 +13,7 @@ from dolphin.utils import full_suffix
 from dolphin.workflows import UnwrapMethod
 
 from ._constants import CONNCOMP_SUFFIX, DEFAULT_CCL_NODATA, DEFAULT_UNW_NODATA
-from ._utils import _redirect_unwrapping_log, _zero_from_mask
+from ._utils import _zero_from_mask
 
 logger = logging.getLogger("dolphin")
 
@@ -200,3 +201,13 @@ def multiscale_unwrap(
             u_src.write(unw, 1)
 
     return Path(unw_filename), Path(conncomp_filename)
+
+
+def _redirect_unwrapping_log(unw_filename: Filename, method: str):
+    import journal
+
+    logfile = Path(unw_filename).with_suffix(".log")
+    journal.info(f"isce3.unwrap.{method}").device = journal.logfile(
+        fspath(logfile), "w"
+    )
+    logger.info(f"Logging unwrapping output to {logfile}")

--- a/src/dolphin/unwrap/_utils.py
+++ b/src/dolphin/unwrap/_utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from os import fspath
 from pathlib import Path
 
 import rasterio as rio
@@ -150,13 +149,3 @@ def _zero_from_mask(
             like_filename=corr_filename,
         )
     return zeroed_ifg_file, zeroed_corr_file
-
-
-def _redirect_unwrapping_log(unw_filename: Filename, method: str):
-    import journal
-
-    logfile = Path(unw_filename).with_suffix(".log")
-    journal.info(f"isce3.unwrap.{method}").device = journal.logfile(
-        fspath(logfile), "w"
-    )
-    logger.info(f"Logging unwrapping output to {logfile}")

--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -17,7 +17,7 @@ import numpy as np
 from numpy.typing import ArrayLike, DTypeLike
 from osgeo import gdal, gdal_array, gdalconst
 
-from dolphin._types import Bbox, Filename, P, Strides, T
+from dolphin._types import Filename, P, Strides, T
 
 DateOrDatetime = Union[datetime.date, datetime.datetime]
 
@@ -518,121 +518,6 @@ def format_dates(*dates: DateOrDatetime, fmt: str = "%Y%m%d", sep: str = "_") ->
 
 # Keep alias for now, but deprecate
 _format_date_pair = format_date_pair
-
-
-def prepare_geometry(
-    geometry_dir: Path,
-    geo_files: Sequence[Path],
-    matching_file: Path,
-    dem_file: Optional[Path],
-    epsg: int,
-    out_bounds: Bbox,
-    strides: Optional[dict[str, int]] = None,
-) -> dict[str, Path]:
-    """Prepare geometry files.
-
-    Parameters
-    ----------
-    geometry_dir : Path
-        Output directory for geometry files.
-    geo_files : list[Path]
-        list of geometry files.
-    matching_file : Path
-        Matching file.
-    dem_file : Optional[Path]
-        DEM file.
-    epsg : int
-        EPSG code.
-    out_bounds : Bbox
-        Output bounds.
-    strides : Dict[str, int], optional
-        Strides for resampling, by default {"x": 1, "y": 1}.
-
-    Returns
-    -------
-    Dict[str, Path]
-        Dictionary of prepared geometry files.
-
-    """
-    from dolphin import stitching
-    from dolphin.io import DEFAULT_TIFF_OPTIONS, format_nc_filename
-
-    if strides is None:
-        strides = {"x": 1, "y": 1}
-    geometry_dir.mkdir(exist_ok=True)
-
-    stitched_geo_list = {}
-
-    if geo_files[0].name.endswith(".h5"):
-        # ISCE3 geocoded SLCs
-        datasets = ["los_east", "los_north", "layover_shadow_mask"]
-        nodatas = [0, 0, 127]
-
-        for nodata, ds_name in zip(nodatas, datasets):
-            outfile = geometry_dir / f"{ds_name}.tif"
-            logger.info(f"Creating {outfile}")
-            stitched_geo_list[ds_name] = outfile
-            ds_path = f"/data/{ds_name}"
-            cur_files = [format_nc_filename(f, ds_name=ds_path) for f in geo_files]
-
-            if ds_name not in "layover_shadow_mask":
-                options = (*DEFAULT_TIFF_OPTIONS, "NBITS=16")
-            else:
-                options = DEFAULT_TIFF_OPTIONS
-            stitching.merge_images(
-                cur_files,
-                outfile=outfile,
-                driver="GTiff",
-                out_bounds=out_bounds,
-                out_bounds_epsg=epsg,
-                in_nodata=nodata,
-                out_nodata=nodata,
-                target_aligned_pixels=True,
-                strides=strides,
-                resample_alg="nearest",
-                overwrite=False,
-                options=options,
-            )
-
-        if dem_file:
-            height_file = geometry_dir / "height.tif"
-            stitched_geo_list["height"] = height_file
-            if not height_file.exists():
-                logger.info(f"Creating {height_file}")
-                stitching.warp_to_match(
-                    input_file=dem_file,
-                    match_file=matching_file,
-                    output_file=height_file,
-                    resample_alg="cubic",
-                )
-    else:
-        # ISCE2 radar coordinates
-        dsets = {
-            "hgt.rdr": "height",
-            "incLocal.rdr": "incidence_angle",
-            "lat.rdr": "latitude",
-            "lon.rdr": "longitude",
-        }
-
-        for geo_file in geo_files:
-            if geo_file.stem in dsets:
-                out_name = dsets[geo_file.stem]
-            elif geo_file.name in dsets:
-                out_name = dsets[geo_file.name]
-                continue
-
-            out_file = geometry_dir / (out_name + ".tif")
-            stitched_geo_list[out_name] = out_file
-            logger.info(f"Creating {out_file}")
-
-            stitching.warp_to_match(
-                input_file=geo_file,
-                match_file=matching_file,
-                output_file=out_file,
-                resample_alg="cubic",
-            )
-
-    return stitched_geo_list
 
 
 def compute_out_shape(

--- a/tests/test_unwrap.py
+++ b/tests/test_unwrap.py
@@ -1,5 +1,4 @@
 import importlib.util
-import os
 from pathlib import Path
 
 import numpy as np
@@ -359,21 +358,3 @@ class TestWhirlwind:
         )
         assert out_path.exists()
         assert conncomp_path.exists()
-
-
-@pytest.mark.skipif(os.environ.get("NUMBA_DISABLE_JIT") == "1", reason="JIT disabled")
-def test_compute_phase_diffs():
-    # test on a 2D array with no phase jumps > pi
-    phase1 = np.array([[0, 1], [1, 2]], dtype=float)
-    expected1 = np.array([[0, 0], [0, 0]], dtype=float)
-    assert np.allclose(dolphin.unwrap.compute_phase_diffs(phase1), expected1)
-
-    # test on a 2D array with some phase jumps > pi at the top-left pixel
-    phase2 = np.array([[0, 3.15], [3.15, 0]], dtype=float)
-    expected2 = np.array([[2, 0], [0, 0]], dtype=float)
-    assert np.allclose(dolphin.unwrap.compute_phase_diffs(phase2), expected2)
-
-    # test on a larger 2D array
-    phase3 = np.full((10, 10), np.pi, dtype=float)
-    expected3 = np.zeros((10, 10), dtype=float)
-    assert np.allclose(dolphin.unwrap.compute_phase_diffs(phase3), expected3)


### PR DESCRIPTION
- Remove `_format_for_gdal()` which is never invoked.
- Remove the numba-decorated phase difference helpers `compute_phase_diffs`
- Move the _redirect_unwrapping_log() to dolphin/unwrap/_tophu.py).
- Update type annotations in unwrap._utils
- Move `prepare_geometry` to `corrections` workflow