### PR TITLE
Add `fmt=file_date_fmt` to all `get_dates` call to avoid file format assumptions

### DIFF
--- a/src/dolphin/atmosphere/ionosphere.py
+++ b/src/dolphin/atmosphere/ionosphere.py
@@ -41,6 +41,7 @@ def estimate_ionospheric_delay(
     output_dir: Path,
     epsg: int,
     bounds: Bbox,
+    file_date_fmt: str = "%Y%m%d",
 ) -> list[Path]:
     """Estimate the range delay (in meters) caused by ionosphere for each interferogram.
 
@@ -67,6 +68,9 @@ def estimate_ionospheric_delay(
         the EPSG code of the input data
     bounds : Bbox
         Output bounds.
+    file_date_fmt : str, optional
+        The format string to use when parsing the dates from the file names.
+        Default is "%Y%m%d".
 
     Returns
     -------
@@ -128,7 +132,7 @@ def estimate_ionospheric_delay(
     ds_inc_angle = ds_inc_angle[:ds_num_lats, :ds_num_lons]
 
     for ifg in ifg_file_list:
-        ref_date, sec_date = get_dates(ifg)
+        ref_date, sec_date = get_dates(ifg, fmt=file_date_fmt)
 
         name = f"{format_date_pair(ref_date, sec_date)}_ionoDelay.tif"
         iono_delay_product_name = output_iono / name

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -260,6 +260,7 @@ def run(
         contained_compressed_slcs=any(is_compressed),
         reference_date=reference_date,
         extra_reference_date=extra_reference_date,
+        file_date_fmt=cfg.input_options.cslc_date_fmt,
     )
     return (
         ifg_file_list,
@@ -279,6 +280,7 @@ def create_ifgs(
     reference_date: datetime.datetime,
     extra_reference_date: datetime.datetime | None = None,
     dry_run: bool = False,
+    file_date_fmt: str = "%Y%m%d",
 ) -> list[Path]:
     """Create the list of interferograms for the `phase_linked_slcs`.
 
@@ -300,6 +302,9 @@ def create_ifgs(
     dry_run : bool
         Flag indicating that the ifgs should not be written to disk.
         Default = False (ifgs will be created).
+    file_date_fmt : str, optional
+        The format string to use when parsing the dates from the file names.
+        Default is "%Y%m%d".
 
     Returns
     -------
@@ -321,7 +326,7 @@ def create_ifgs(
 
     ifg_file_list: list[Path] = []
 
-    secondary_dates = [get_dates(f)[0] for f in phase_linked_slcs]
+    secondary_dates = [get_dates(f, fmt=file_date_fmt)[0] for f in phase_linked_slcs]
     # TODO: if we manually set an ifg network (i.e. not rely on spurt),
     # we may still want to just pass it right to `Network`
     if not contained_compressed_slcs and extra_reference_date is None:
@@ -442,7 +447,7 @@ def create_ifgs(
     for p in written_ifgs - requested_ifgs:
         p.unlink()
 
-    if len(set(get_dates(ifg_file_list[0]))) == 1:
+    if len(set(get_dates(ifg_file_list[0], fmt=file_date_fmt))) == 1:
         same_date_ifg = ifg_file_list.pop(0)
         same_date_ifg.unlink()
     return ifg_file_list


### PR DESCRIPTION
No functional changes - simplify ensuring that the specified date format we want gets used in later timeseries stages, rather than jumping to assume it's `%Y%m%d` there.