### PR TITLE
Simplify reference index logic for `ALWAYS_FIRST` in `stack.py`, cut `FIRST_PER_MINISTACK`

### DIFF
--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -476,7 +476,6 @@ class MiniStackPlanner(BaseStack):
 
             if compressed_idx is not None:
                 compressed_reference_idx = compressed_idx
-
             elif self.compressed_slc_plan == CompressedSlcPlan.ALWAYS_FIRST:
                 # Here, CompSLCs have same base phase, but different "residual" added on
                 compressed_reference_idx = max(0, num_ccslc - 1)

--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -402,9 +402,12 @@ class MiniStackPlanner(BaseStack):
     """Class for planning the processing of batches of SLCs."""
 
     max_num_compressed: int = 5
-    output_reference_idx: int = Field(
-        0,
-        description="Index of the SLC to use as reference during phase linking",
+    output_reference_idx: Optional[int] = Field(
+        None,
+        description=(
+            "Index of the SLC to use as interferogram reference after phase linking. If"
+            " not set, uses the CompressedSlcPlan default"
+        ),
     )
     compressed_slc_plan: CompressedSlcPlan = CompressedSlcPlan.ALWAYS_FIRST
 
@@ -416,13 +419,20 @@ class MiniStackPlanner(BaseStack):
             msg = "Cannot create ministacks with size < 2"
             raise ValueError(msg)
 
-        # For now, only allow `compressed_idx` when doing a single batch.
-        # The logic is more complicated for multiple `compressed_idx`s, and
-        # it's unclear who would need that
-        if compressed_idx is not None and ministack_size < len(self.file_list):
-            raise ValueError(
-                "Cannot set `compressed_idx` when creating multiple ministacks."
-            )
+        # Check for problems with multi-batch inputs.
+        # For now, `compressed_idx` logic is more complicated/ambiguous for multiple
+        # `compressed_idx`s, and it's unclear who would need that
+        # Likewise for `last_per_ministack` - useful for separate runs, but unclear
+        # not why you'd want it for multi-ministack sequential runs
+        if ministack_size < len(self.file_list):
+            if compressed_idx is not None:
+                raise ValueError(
+                    "Cannot set `compressed_idx` when creating multiple ministacks."
+                )
+            if self.compressed_slc_plan == CompressedSlcPlan.LAST_PER_MINISTACK:
+                raise ValueError(
+                    "'last_per_ministack' cannot be used for multiple ministacks"
+                )
 
         output_ministacks: list[MiniStackInfo] = []
 
@@ -467,28 +477,20 @@ class MiniStackPlanner(BaseStack):
             if compressed_idx is not None:
                 compressed_reference_idx = compressed_idx
             elif self.compressed_slc_plan == CompressedSlcPlan.ALWAYS_FIRST:
-                # Simplest operational version: CompSLCs have same base phase,
-                # but different "residual" added on
-                # We use the `output_reference_idx`, 0 by default, but this index
-                # may be passed in if we are manually specifying an output
-                compressed_reference_idx = self.output_reference_idx
-            elif self.compressed_slc_plan == CompressedSlcPlan.FIRST_PER_MINISTACK:
-                # Like Ansari, 2017 paper: each ministack is "self contained"
-                compressed_reference_idx = num_ccslc
-                # Ansari, 2017 also had output_reference_idx = num_ccslcs, and
-                # used the "Datum Adjustment" step to get outputs relative to day 0
-                # Here, we'll use 0 (or manually specified)
-            elif self.compressed_slc_plan == CompressedSlcPlan.LAST_PER_MINISTACK:
-                # Alternative that allows sequential interferograms across ministacks
-                compressed_reference_idx = -1
+                # Here, CompSLCs have same base phase, but different "residual" added on
+                compressed_reference_idx = max(0, num_ccslc - 1)
 
-            if self.compressed_slc_plan == CompressedSlcPlan.LAST_PER_MINISTACK:
-                # For this, we'll always use the most recent compressed SLC as output
-                # reference so that we can connected stacks, but minimize the temporal
-                # baseline of interferograms we form
-                output_reference_idx = num_ccslc - 1
-            else:
+            # Set the `output_reference_idx`, used for making interferograms
+            if self.output_reference_idx is not None:
+                # may be passed in if we are manually specifying an output:
                 output_reference_idx = self.output_reference_idx
+            else:
+                # Otherwise, this will be the *latest* compressed SLC
+                # For the `ALWAYS_FIRST` plan, this leads to all interferograms
+                # looking like single-reference, relative to day 1
+                # For `LAST_PER_MINISTACK`, the interferograms are formed
+                # which are the shortest possible temporal baseline for the given inputs
+                output_reference_idx = max(0, num_ccslc - 1)
 
             cur_ministack = MiniStackInfo(
                 file_list=combined_files,

--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -476,9 +476,13 @@ class MiniStackPlanner(BaseStack):
 
             if compressed_idx is not None:
                 compressed_reference_idx = compressed_idx
+
             elif self.compressed_slc_plan == CompressedSlcPlan.ALWAYS_FIRST:
                 # Here, CompSLCs have same base phase, but different "residual" added on
                 compressed_reference_idx = max(0, num_ccslc - 1)
+            elif self.compressed_slc_plan == CompressedSlcPlan.LAST_PER_MINISTACK:
+                # Here, CompSLCs have same base phase, but different "residual" added on
+                compressed_reference_idx = -1
 
             # Set the `output_reference_idx`, used for making interferograms
             if self.output_reference_idx is not None:

--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -84,11 +84,11 @@ class PhaseLinkingOptions(BaseModel, extra="forbid"):
         ),
         gt=0,
     )
-    output_reference_idx: int = Field(
-        0,
+    output_reference_idx: Optional[int] = Field(
+        None,
         description=(
-            "Index of input SLC to use for making phase linked interferograms after"
-            " EVD/EMI."
+            "Index of the SLC to use as interferogram reference after phase linking. If"
+            " not set, uses the CompressedSlcPlan default"
         ),
     )
     half_window: HalfWindow = HalfWindow()

--- a/src/dolphin/workflows/sequential.py
+++ b/src/dolphin/workflows/sequential.py
@@ -49,7 +49,7 @@ def run_wrapped_phase_sequential(
     similarity_nearest_n: int | None = None,
     compressed_slc_plan: CompressedSlcPlan = CompressedSlcPlan.ALWAYS_FIRST,
     max_num_compressed: int = 100,
-    output_reference_idx: int = 0,
+    output_reference_idx: int | None = None,
     new_compressed_reference_idx: int | None = None,
     cslc_date_fmt: str = "%Y%m%d",
     block_shape: tuple[int, int] = (512, 512),

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -233,9 +233,13 @@ def run(
         )
 
     logger.info(f"Creating virtual interferograms from {len(phase_linked_slcs)} files")
-    reference_date = [
-        get_dates(f, fmt=cfg.input_options.cslc_date_fmt)[0] for f in input_file_list
-    ][cfg.phase_linking.output_reference_idx]
+    ref_idx = cfg.phase_linking.output_reference_idx or 0
+
+    def base_phase_date(filename):
+        """Get the base phase of either real of compressed slcs."""
+        return get_dates(filename, fmt=cfg.input_options.cslc_date_fmt)[0]
+
+    reference_date = [base_phase_date(f) for f in input_file_list][ref_idx]
 
     # TODO: remove this bad back to get around spurt's required input
     # Reading direct nearest-3 ifgs is not working due to some slicing problem

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -233,7 +233,8 @@ def run(
         )
 
     logger.info(f"Creating virtual interferograms from {len(phase_linked_slcs)} files")
-    ref_idx = cfg.phase_linking.output_reference_idx or 0
+    num_ccslc = sum(is_compressed)
+    ref_idx = cfg.phase_linking.output_reference_idx or max(0, num_ccslc - 1)
 
     def base_phase_date(filename):
         """Get the base phase of either real of compressed slcs."""

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -264,8 +264,7 @@ def test_compressed_idx_setting(slc_file_list, slc_date_list, is_compressed):
     assert ministacks[0].output_reference_date == slc_date_list[0]
 
 
-@pytest.mark.parametrize("plan", ["always_first", "last_per_ministack"])
-def test_compressed_plans(slc_file_list, slc_date_list, is_compressed, plan):
+def test_compressed_plans_always_first(slc_file_list, slc_date_list, is_compressed):
     """Check the planning works to set a manually passed compressed index."""
     is_compressed = [False] * len(slc_file_list)
     ministack_planner = MiniStackPlanner(
@@ -273,7 +272,7 @@ def test_compressed_plans(slc_file_list, slc_date_list, is_compressed, plan):
         dates=slc_date_list,
         is_compressed=is_compressed,
         output_folder=Path("fake_dir"),
-        compressed_slc_plan=plan,
+        compressed_slc_plan="always_first",
     )
 
     # This currently works ONLY for one single ministack planning
@@ -282,13 +281,34 @@ def test_compressed_plans(slc_file_list, slc_date_list, is_compressed, plan):
     ministacks = ministack_planner.plan(ms_size)
 
     compslcs = [m.get_compressed_slc_info() for m in ministacks]
-    if plan == "always_first":
-        assert all(c.reference_date == slc_date_list[0] for c in compslcs)
-    elif plan == "last_per_ministack":
-        assert compslcs[0].reference_date == slc_date_list[ms_size - 1]
-        assert compslcs[1].reference_date == slc_date_list[2 * ms_size - 1]
-        assert compslcs[2].reference_date == slc_date_list[3 * ms_size - 1]
-    # elif plan == "first_per_ministack":
-    #     assert compslcs[0].reference_date == slc_date_list[0]
-    #     assert compslcs[1].reference_date == slc_date_list[ms_size]
-    #     assert compslcs[2].reference_date == slc_date_list[ms_size * 2]
+    assert all(c.reference_date == slc_date_list[0] for c in compslcs)
+
+
+def test_compressed_plans_last_per_ministack(
+    slc_file_list, slc_date_list, is_compressed
+):
+    """Check the planning works to set a manually passed compressed index."""
+    is_compressed = [False] * len(slc_file_list)
+    # This currently works ONLY for one single ministack planning
+    with pytest.raises(ValueError):
+        ministack_planner = MiniStackPlanner(
+            file_list=slc_file_list,
+            dates=slc_date_list,
+            is_compressed=is_compressed,
+            output_folder=Path("fake_dir"),
+            compressed_slc_plan="last_per_ministack",
+        )
+        ministacks = ministack_planner.plan(3)
+
+    ms_size = 4
+    ministack_planner = MiniStackPlanner(
+        file_list=slc_file_list[:ms_size],
+        dates=slc_date_list[:ms_size],
+        is_compressed=is_compressed[:ms_size],
+        output_folder=Path("fake_dir"),
+        compressed_slc_plan="last_per_ministack",
+    )
+    ministacks = ministack_planner.plan(ms_size)
+    compslcs = [m.get_compressed_slc_info() for m in ministacks]
+    assert len(compslcs) == 1
+    assert compslcs[0].reference_date == slc_date_list[ms_size - 1]

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -264,9 +264,7 @@ def test_compressed_idx_setting(slc_file_list, slc_date_list, is_compressed):
     assert ministacks[0].output_reference_date == slc_date_list[0]
 
 
-@pytest.mark.parametrize(
-    "plan", ["always_first", "first_per_ministack", "last_per_ministack"]
-)
+@pytest.mark.parametrize("plan", ["always_first", "last_per_ministack"])
 def test_compressed_plans(slc_file_list, slc_date_list, is_compressed, plan):
     """Check the planning works to set a manually passed compressed index."""
     is_compressed = [False] * len(slc_file_list)
@@ -286,11 +284,11 @@ def test_compressed_plans(slc_file_list, slc_date_list, is_compressed, plan):
     compslcs = [m.get_compressed_slc_info() for m in ministacks]
     if plan == "always_first":
         assert all(c.reference_date == slc_date_list[0] for c in compslcs)
-    elif plan == "first_per_ministack":
-        assert compslcs[0].reference_date == slc_date_list[0]
-        assert compslcs[1].reference_date == slc_date_list[ms_size]
-        assert compslcs[2].reference_date == slc_date_list[ms_size * 2]
     elif plan == "last_per_ministack":
         assert compslcs[0].reference_date == slc_date_list[ms_size - 1]
         assert compslcs[1].reference_date == slc_date_list[2 * ms_size - 1]
         assert compslcs[2].reference_date == slc_date_list[3 * ms_size - 1]
+    # elif plan == "first_per_ministack":
+    #     assert compslcs[0].reference_date == slc_date_list[0]
+    #     assert compslcs[1].reference_date == slc_date_list[ms_size]
+    #     assert compslcs[2].reference_date == slc_date_list[ms_size * 2]


### PR DESCRIPTION
We want the `output_reference_idx` to move forward one each time when doing `ALWAYS_FIRST`. Otherwise, the results look much noisier (though still roughly correct)

Note that this was previously found by @mirzaees , but I lost how important it was in the refactors of `stack.py` of #334 since the outputs can still look somewhat correct.

Before (main): 
![image](https://github.com/user-attachments/assets/21788295-a837-4869-bf0e-d22ba0e92ac7)

After 
![image](https://github.com/user-attachments/assets/8ff545df-f6ba-4d9c-ab0e-137a272af665)


I'm not fully deleting the `output_reference_idx` at the moment in case we do want to pass in some specific date that we know should be the "best" single-reference interferogram date to use