### PR TITLE
`OutputOptions`: Only require `bounds_epsg` if specifying `bounds`, cut `resolution`

### DIFF
--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -291,19 +291,12 @@ class InputOptions(BaseModel, extra="forbid"):
 class OutputOptions(BaseModel, extra="forbid"):
     """Options for the output size/format/compressions."""
 
-    output_resolution: Optional[dict[str, int]] = Field(
-        # {"x": 20, "y": 20},
-        # TODO: how to get a blank "x" and "y" in the schema printed instead of nothing?
-        None,
-        description="Output (x, y) resolution (in units of input data)",
-    )
     strides: dict[str, int] = Field(
         {"x": 1, "y": 1},
         description=(
-            "Alternative to specifying output resolution: Specify the (x, y) strides"
-            " (decimation factor) to perform while processing input. For example,"
-            " strides of [4, 2] would turn an input resolution of [5, 10] into an"
-            " output resolution of [20, 20]."
+            "Specify the (x, y) strides (decimation factor) to perform while processing"
+            " input. For example, strides of {x: 4, y: 2} would turn an input"
+            " resolution of [5, 10] into an output resolution of [20, 20]."
         ),
         validate_default=True,
     )
@@ -388,40 +381,6 @@ class OutputOptions(BaseModel, extra="forbid"):
             msg = "Must specify `bounds_epsg` if `bounds` is provided."
             raise ValueError(msg)
         return bounds_epsg
-
-    @field_validator("strides")
-    @classmethod
-    def _check_strides_against_res(cls, strides, info):
-        """Compute the output resolution from the strides."""
-        resolution = info.data.get("output_resolution")
-        if strides is not None and resolution is not None:
-            msg = "Cannot specify both strides and output_resolution."
-            raise ValueError(msg)
-        elif strides is None and resolution is None:
-            msg = "Must specify either strides or output_resolution."
-            raise ValueError(msg)
-
-        # Check that the dict has the correct keys
-        if strides is not None:
-            if set(strides.keys()) != {"x", "y"}:
-                msg = "Strides must be a dict with keys 'x' and 'y'"
-                raise ValueError(msg)
-            # and that the strides are integers
-            if not all(isinstance(v, int) for v in strides.values()):
-                msg = "Strides must be integers"
-                raise ValueError(msg)
-        if resolution is not None:
-            if set(resolution.keys()) != {"x", "y"}:
-                msg = "Resolution must be a dict with keys 'x' and 'y'"
-                raise ValueError(msg)
-            # and that the resolution is valid, > 0. Can be int or float
-            if any(v <= 0 for v in resolution.values()):
-                msg = "Resolutions must be > 0"
-                raise ValueError(msg)
-            # TODO: compute strides from resolution
-            msg = "output_resolution not yet implemented. Use `strides`."
-            raise NotImplementedError(msg)
-        return strides
 
     @field_validator("extra_reference_date", mode="after")
     @classmethod

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -474,7 +474,7 @@ def _get_mask(
     output_dir: Path,
     output_bounds: Bbox | tuple[float, float, float, float] | None,
     output_bounds_wkt: str | None,
-    output_bounds_epsg: int,
+    output_bounds_epsg: int | None,
     like_filename: Filename,
     layover_shadow_mask: Filename | None,
     cslc_file_list: Sequence[Filename],
@@ -497,6 +497,8 @@ def _get_mask(
 
     # Also mask outside the area of interest if we've specified a small bounds
     if output_bounds is not None or output_bounds_wkt is not None:
+        if output_bounds_epsg is None:
+            raise ValueError("Must supply output_bounds_epsg for bounds")
         # Make a mask just from the bounds
         bounds_mask_filename = output_dir / "bounds_mask.tif"
         masking.create_bounds_mask(

--- a/tests/test_workflows_config.py
+++ b/tests/test_workflows_config.py
@@ -106,7 +106,6 @@ def test_unwrap_options_defaults():
 
 def test_outputs_defaults():
     opts = config.OutputOptions()
-    assert opts.output_resolution is None
     assert opts.strides == {"x": 1, "y": 1}
     assert opts.hdf5_creation_options == {
         "chunks": [128, 128],


### PR DESCRIPTION
Problem with `bounds_epsg` was noted in https://github.com/isce-framework/dolphin/discussions/590#discussioncomment-13144615 by @giorgoskouroupis
