### PR TITLE
Fix: Remove per-burst phase linking dirs that are empty

### DIFF
--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -114,9 +114,9 @@ def run(
     ]
     for _, burst_cfg in wrapped_phase_cfgs:
         burst_cfg.create_dir_tree()
-    # Remove the mid-level directories which will be empty due to re-grouping
-    _remove_dir_if_empty(cfg.phase_linking._directory)
-    _remove_dir_if_empty(cfg.ps_options._directory)
+        # Remove the mid-level directories which will be empty due to re-grouping
+        _remove_dir_if_empty(burst_cfg.timeseries_options._directory)
+        _remove_dir_if_empty(burst_cfg.unwrap_options._directory)
 
     ifg_file_list: list[Path] = []
     temp_coh_file_list: list[Path] = []

--- a/tests/test_workflows_displacement.py
+++ b/tests/test_workflows_displacement.py
@@ -59,6 +59,15 @@ def test_displacement_run_single(opera_slc_files: list[Path], tmpdir):
             paths.timeseries_paths[0]
         )
 
+        # Check the structure of the per-burst wrapped phase directories
+        burst_dir = next(iter(paths.comp_slc_dict.values()))[0].parent.parent
+        assert (burst_dir / "PS").exists()
+        assert (burst_dir / "linked_phase").exists()
+        assert (burst_dir / "interferograms").exists()
+        # Check the non-phase linking folders were removed
+        assert not (burst_dir / "unwrapped").exists()
+        assert not (burst_dir / "timeseries").exists()
+
 
 def test_displacement_run_single_official_opera_naming(
     opera_slc_files_official: list[Path], tmpdir


### PR DESCRIPTION
The `timeseries` and `unwrapped` directories within phase linking folders were being created, but not removed. the `_remove_dir_if_empty` was added to do this, but was not used correctly.