### PR TITLE
Pass through `timeseries_options.reference_point` during `displacement.py` workflow

### DIFF
--- a/src/dolphin/timeseries.py
+++ b/src/dolphin/timeseries.py
@@ -52,7 +52,7 @@ def run(
     correlation_threshold: float = 0.0,
     block_shape: tuple[int, int] = (256, 256),
     num_threads: int = 4,
-    reference_point: tuple[int, int] = (-1, -1),
+    reference_point: tuple[int, int] | None = None,
     wavelength: float | None = None,
     add_overviews: bool = True,
     extra_reference_date: datetime | None = None,
@@ -141,7 +141,7 @@ def run(
     unwrapped_paths = sorted(unwrapped_paths, key=str)
     Path(output_dir).mkdir(exist_ok=True, parents=True)
 
-    if reference_point == (-1, -1):
+    if reference_point is None:
         logger.info("Selecting a reference point for unwrapped interferograms")
         ref_point = select_reference_point(
             quality_file=quality_file,

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -244,6 +244,7 @@ def run(
             corr_paths=stitched_paths.interferometric_corr_paths,
             # TODO: Right now we don't have the option to pick a different candidate
             # or quality file. Figure out if this is worth exposing
+            reference_point=cfg.timeseries_options.reference_point,
             quality_file=stitched_paths.temp_coh_file,
             reference_candidate_threshold=0.95,
             output_dir=ts_opts._directory,

--- a/tests/test_workflows_displacement.py
+++ b/tests/test_workflows_displacement.py
@@ -28,6 +28,9 @@ def test_displacement_run_single(opera_slc_files: list[Path], tmpdir):
             phase_linking={
                 "ministack_size": 500,
             },
+            timeseries_options={
+                "reference_point": (5, 6),
+            },
         )
         paths = displacement.run(cfg)
 
@@ -67,6 +70,9 @@ def test_displacement_run_single(opera_slc_files: list[Path], tmpdir):
         # Check the non-phase linking folders were removed
         assert not (burst_dir / "unwrapped").exists()
         assert not (burst_dir / "timeseries").exists()
+
+        # Check the reference point used
+        assert paths.reference_point == (5, 6)
 
 
 def test_displacement_run_single_official_opera_naming(


### PR DESCRIPTION
Closes #601
