### PR TITLE
Throw better error for `dolphin` empty cli

### DIFF
--- a/src/dolphin/cli.py
+++ b/src/dolphin/cli.py
@@ -10,7 +10,7 @@ def main() -> int:
     # TODO: Is there any way to slot this into tyro's argparse
     # Only found this hacky way
     # https://github.com/brentyi/tyro/issues/132#issuecomment-1978319762
-    if sys.argv[1] == "--version":
+    if len(sys.argv) > 1 and sys.argv[1] == "--version":
         print(__version__)
         raise SystemExit(os.EX_OK)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
 import sys
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
 
@@ -10,6 +10,17 @@ from dolphin.cli import main
 
 # Match the start of help output
 HELP_LINE = "usage: dolphin"
+
+
+def test_empty(monkeypatch: pytest.MonkeyPatch):
+    with monkeypatch.context() as m:
+        m.setattr(sys, "argv", ["dolphin"])
+        f = StringIO()
+        with redirect_stderr(f), pytest.raises(SystemExit):
+            main()
+
+        help_text = f.getvalue()
+        assert "Required options" in help_text
 
 
 def test_help(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
Instead of `IndexError: list index out of range` due to the `sys.argv[1]`, this raises the default `tyro` error.