### PR TITLE
`unwrap.py`: Combine sliding window mask with similarity mask for interpolation

### DIFF
--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -315,6 +315,7 @@ def unwrap(
 
     unwrapper_ifg_filename = Path(ifg_filename)
     unwrapper_unw_filename = Path(unw_filename)
+    unwrapper_corr_filename = Path(corr_filename)
     name_change = "."
 
     ifg = io.load_gdal(ifg_filename, masked=True)
@@ -373,16 +374,16 @@ def unwrap(
 
         pre_interp_ifg = io.load_gdal(pre_interp_ifg_filename, masked=True).filled(0)
 
-        corr = io.load_gdal(corr_filename)
-        if similarity_filename and preproc_options.interpolation_similarity_threshold:
-            cutoff = preproc_options.interpolation_similarity_threshold
-            logger.info(f"Masking pixels with similarity below {cutoff}")
+        corr = io.load_gdal(corr_filename, masked=True).filled(0)
+        cutoff = preproc_options.interpolation_cor_threshold
+        logger.info(f"Masking pixels with correlation below {cutoff}")
+        coherent_pixel_mask = corr >= cutoff
+        if similarity_filename and (
+            sim_cutoff := preproc_options.interpolation_similarity_threshold
+        ):
+            logger.info(f"Masking pixels with similarity below {sim_cutoff}")
             sim = io.load_gdal(similarity_filename, masked=True).filled(0)
-            coherent_pixel_mask = sim[:] >= cutoff
-        else:
-            cutoff = preproc_options.interpolation_cor_threshold
-            logger.info(f"Masking pixels with correlation below {cutoff}")
-            coherent_pixel_mask = corr[:] >= cutoff
+            coherent_pixel_mask &= sim >= sim_cutoff
 
         logger.info(f"Interpolating {pre_interp_ifg_filename} -> {interp_ifg_filename}")
         modified_ifg = interpolate(
@@ -391,6 +392,14 @@ def unwrap(
             weight_cutoff=cutoff,
             max_radius=preproc_options.max_radius,
         )
+        # Now we set the pixels we masked to have 0 correlation so SNAHPU ignores them
+        masked_corr_filename = Path(scratchdir or ".") / (
+            Path(corr_filename).stem.split(".")[0] + ".masked.cor.tif"
+        )
+        io.write_arr(
+            arr=np.where(coherent_pixel_mask, corr, 0), output_name=masked_corr_filename
+        )
+        unwrapper_corr_filename = masked_corr_filename
 
         logger.info(f"Writing interpolated output to {interp_ifg_filename}")
         io.write_arr(
@@ -408,7 +417,7 @@ def unwrap(
         # Pass everything to snaphu-py
         unw_path, conncomp_path = unwrap_snaphu_py(
             unwrapper_ifg_filename,
-            corr_filename,
+            unwrapper_corr_filename,
             unwrapper_unw_filename,
             nlooks,
             ntiles=snaphu_opts.ntiles,

--- a/src/dolphin/unwrap/_unwrap.py
+++ b/src/dolphin/unwrap/_unwrap.py
@@ -392,14 +392,16 @@ def unwrap(
             weight_cutoff=cutoff,
             max_radius=preproc_options.max_radius,
         )
-        # Now we set the pixels we masked to have 0 correlation so SNAHPU ignores them
-        masked_corr_filename = Path(scratchdir or ".") / (
-            Path(corr_filename).stem.split(".")[0] + ".masked.cor.tif"
-        )
-        io.write_arr(
-            arr=np.where(coherent_pixel_mask, corr, 0), output_name=masked_corr_filename
-        )
-        unwrapper_corr_filename = masked_corr_filename
+        if preproc_options.zero_correlation_where_interpolating:
+            # Set the pixels we masked to have 0 correlation so SNAHPU ignores them
+            masked_corr_filename = Path(scratchdir or ".") / (
+                Path(corr_filename).stem.split(".")[0] + ".masked.cor.tif"
+            )
+            io.write_arr(
+                arr=np.where(coherent_pixel_mask, corr, 0),
+                output_name=masked_corr_filename,
+            )
+            unwrapper_corr_filename = masked_corr_filename
 
         logger.info(f"Writing interpolated output to {interp_ifg_filename}")
         io.write_arr(

--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -196,10 +196,8 @@ class InterferogramNetwork(BaseModel, extra="forbid"):
         indexes = self.indexes
         # Check if more than one has been set:
         if ref_idx is None and max_bw is None and max_tb is None and indexes is None:
-            logger.debug(
-                "No network configuration options were set. Using single-reference."
-            )
-            self.reference_idx = 0
+            logger.debug("No network configuration options were set. Using nearest-3.")
+            self.max_bandwidth = 3
         return self
 
 

--- a/src/dolphin/workflows/config/_unwrap_options.py
+++ b/src/dolphin/workflows/config/_unwrap_options.py
@@ -67,11 +67,11 @@ class PreprocessOptions(BaseModel, extra="forbid"):
         description="(for interpolation) Maximum radius to find scatterers.",
     )
     interpolation_cor_threshold: float = Field(
-        0.3,
+        0.25,
         description=(
-            "Threshold on the correlation raster to use for interpolation. Pixels with"
-            " less than this value are replaced by a weighted combination of"
-            " neighboring pixels."
+            "Threshold on the sliding-window correlation to use for"
+            " masking+interpolation.Pixels with less than this value are replaced by a"
+            " weighted combination of neighboring pixels."
         ),
         ge=0.0,
         le=1.0,
@@ -79,8 +79,8 @@ class PreprocessOptions(BaseModel, extra="forbid"):
     interpolation_similarity_threshold: float = Field(
         0.3,
         description=(
-            "Threshold on the correlation raster to use for interpolation. Pixels with"
-            " less than this value are replaced by a weighted combination of"
+            "Threshold on the phase similarity to use for masking+interpolation. "
+            "Pixels with less than this value are replaced by a weighted combination of"
             " neighboring pixels."
         ),
         ge=0.0,

--- a/src/dolphin/workflows/config/_unwrap_options.py
+++ b/src/dolphin/workflows/config/_unwrap_options.py
@@ -86,6 +86,16 @@ class PreprocessOptions(BaseModel, extra="forbid"):
         ge=0.0,
         le=1.0,
     )
+    zero_correlation_where_interpolating: bool = Field(
+        False,
+        description=(
+            "(for interpolation) Set the pixels where we have masked + interpolated"
+            " data to have 0 correlation for the unwrapper. If False, the interpolated"
+            " pixels keep their old correlation. If True, the behavior can be unwrapper"
+            " dependent (the unwrapper may choose to skip over these pixels when"
+            " solving)."
+        ),
+    )
 
 
 class SnaphuOptions(BaseModel, extra="forbid"):


### PR DESCRIPTION
Currently the `corr_filename` (sliding window correlation) has been ignored when doing `run_interpolation` with the similarity raster.

This combines the two thresholds (with an `&`) so that interfeorgrams with heavier noise specific to one day may mask more appropriately