### PR TITLE
Refactor to check for nans in JAX crlb calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,36 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+## [0.42.0](https://github.com/isce-framework/dolphin/compare/v0.41.0...v0.42.0) - 2025-08-19
 
-## [Unreleased](https://github.com/isce-framework/dolphin/compare/v0.40.0...HEAD)
+### Added
+
+### Changed
+- Update workflow defaults for larger half-window and nearest-3 (#634)
+
+### Fixed
+- Fixed JAX CRLB outputs for singular matrix cases
+- Updated `docs/sample_dolphin_config.yaml` for newer structure
+- Fix defaults in dolphin config CLI for interferogram_network settings (#636)
+
+## [0.41.0](https://github.com/isce-framework/dolphin/compare/v0.40.0...v0.41.0) - 2025-08-11
+
+### Added
+
+- `stitching.py`: Add support for specifying output projection by @scottstanie in [#607](https://github.com/isce-framework/dolphin/pull/607)
+- Added Cramér–Rao lower bound (CRLB) estimation output to phase linking results by @scottstanie in [#577](https://github.com/isce-framework/dolphin/pull/577)
+- Add UAVSAR_WAVELENGTH to constants by @scottstanie in [#620](https://github.com/isce-framework/dolphin/pull/620)
+- Add sequential closure phase rasters to phase linking output by @scottstanie in [#618](https://github.com/isce-framework/dolphin/pull/618)
+- Add `apply_mask_to_timeseries` to set masked pixels to nodata in outputs by @scottstanie in [#627](https://github.com/isce-framework/dolphin/pull/627)
+- Stitch and output all per-ministack `temporal_coherence_` and `similarity_` files by @scottstanie in [#615](https://github.com/isce-framework/dolphin/pull/615)
+
+### Changed
+- Fix numerical issues with CRLB calculation by @scottstanie in [#626](https://github.com/isce-framework/dolphin/pull/626)
+
+### Fixed
+- Fix hardcoded port 5000 for moto tests by @scottstanie in [#617](https://github.com/isce-framework/dolphin/pull/617)
+- `masking.py`: Raise `MaskingError` after creating an empty mask by @scottstanie in [#619](https://github.com/isce-framework/dolphin/pull/619)
+
+## [0.40.0](https://github.com/isce-framework/dolphin/compare/v0.39.0...v0.40.0) - 2025-06-30
 
 ### Added
 

--- a/src/dolphin/phase_link/_core.py
+++ b/src/dolphin/phase_link/_core.py
@@ -15,11 +15,10 @@ from jax.typing import ArrayLike
 from dolphin._types import HalfWindow, Strides
 from dolphin.utils import take_looks
 
-from . import covariance, metrics
+from . import covariance, crlb, metrics
 from ._closure_phase import compute_nearest_closure_phases_batch
 from ._eigenvalues import eigh_largest_stack, eigh_smallest_stack
 from ._ps_filling import fill_ps_pixels
-from .crlb import compute_crlb_jax
 
 logger = logging.getLogger("dolphin")
 
@@ -455,7 +454,8 @@ def process_coherence_matrices(
     # Identity used for regularization and for solving
     Id = jnp.eye(n, dtype=Gamma.dtype)
     # repeat the identity matrix for each pixel
-    Id = jnp.tile(Id, (rows, cols, 1, 1))
+    # Id = jnp.tile(Id, (rows, cols, 1, 1))
+    Id = jnp.broadcast_to(Id, (rows, cols, n, n))
 
     if beta > 0:
         # Perform regularization
@@ -464,7 +464,8 @@ def process_coherence_matrices(
     Gamma = jnp.where(Gamma < zero_correlation_threshold, 0, Gamma)
 
     # Attempt to invert Gamma
-    cho, is_lower = cho_factor(Gamma)
+    gamma_jitter = 1e-6
+    cho, is_lower = cho_factor(Gamma + gamma_jitter * Id)
 
     # Check: If it fails the cholesky factor, it's close to singular and
     # we should just fall back to EVD
@@ -516,9 +517,10 @@ def process_coherence_matrices(
 
     # Compute CRLB for each pixel
     if compute_crlb:
-        crlb_std_dev = compute_crlb_jax(
-            C_arrays, num_looks, max(first_real_slc_idx - 1, 0)
-        )
+        # Build X once and do the inverse-free CRLB from X
+        X = crlb._build_fisher_from_abs_gamma(Gamma, Gamma_inv, num_looks)
+        crlb_std_dev = crlb._crlb_from_x(X, max(first_real_slc_idx - 1, 0), 0, 1e-6)
+
     else:
         crlb_std_dev = jnp.zeros(C_arrays.shape[:-1], dtype=jnp.float32)
 

--- a/src/dolphin/phase_link/_core.py
+++ b/src/dolphin/phase_link/_core.py
@@ -454,7 +454,6 @@ def process_coherence_matrices(
     # Identity used for regularization and for solving
     Id = jnp.eye(n, dtype=Gamma.dtype)
     # repeat the identity matrix for each pixel
-    # Id = jnp.tile(Id, (rows, cols, 1, 1))
     Id = jnp.broadcast_to(Id, (rows, cols, n, n))
 
     if beta > 0:

--- a/tests/test_phase_link_crlb.py
+++ b/tests/test_phase_link_crlb.py
@@ -65,7 +65,8 @@ def test_numpy_vs_jax(example: str, aps_var: float) -> None:
             num_looks=num_looks,
             reference_idx=ref_idx,
             aps_variance=aps_var,
-            jitter=0.0,  # disable extra regularization for fair comparison
+            gamma_jitter=0.0,  # disable extra regularization for fair comparison
+            fim_jitter=0.0,
         )
     )
 
@@ -93,7 +94,8 @@ def test_large_n_no_nans() -> None:
             num_looks=num_looks,
             reference_idx=0,
             aps_variance=aps_var,
-            jitter=1e-6,  # Small jitter for numerical stability
+            gamma_jitter=1e-6,  # Small jitter for numerical stability
+            fim_jitter=1e-6,
         )
     )
     assert not np.any(np.isnan(std_jax)), "JAX implementation produced NaNs"
@@ -102,7 +104,7 @@ def test_large_n_no_nans() -> None:
     assert np.all(std_jax[1:] > 0), "All non-reference epochs should have positive std"
 
     # Verify they are reasonably close
-    np.testing.assert_allclose(std_np, std_jax, rtol=1e-3, atol=1e-5)
+    np.testing.assert_allclose(std_np, std_jax, rtol=5e-3, atol=1e-5)
 
 
 @pytest.mark.parametrize("num_acq", [10, 25])
@@ -144,7 +146,8 @@ def test_crlb_with_empirical_coherence(num_acq: int, neighbor_samples: int) -> N
             num_looks=num_looks,
             reference_idx=ref_idx,
             aps_variance=aps_var,
-            jitter=1e-5,
+            gamma_jitter=1e-5,
+            fim_jitter=1e-5,
         )
     )
 


### PR DESCRIPTION
The JAX implementation was getting nans for one inversion, which, after regularization, led to a flat `100` or `1000` in the `crlb_*.tif` instead of the nodata value.
The refactor also takes advantage of pre-inverted `Gamma` matrices to not duplicate work.