### PR TITLE
Fix ability to pass `indexes` when using compressed SLCs

### DIFF
--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -448,16 +448,6 @@ def create_ifgs(
             )
             single_ref_ifgs.append(v.path)  # type: ignore[arg-type]
 
-    if interferogram_network.indexes and interferogram_network.indexes == [(0, -1)]:
-        ifg_file_list.append(single_ref_ifgs[-1])
-        # XXX Fix this hack for later
-        # # This isn't really what we want here, the logic is different than Network:
-        # ifgs = [
-        #     (single_ref_ifgs[ref_idx], single_ref_ifgs[sec_idx])
-        #     for ref_idx, sec_idx in interferogram_network.indexes
-        # ]
-        # ifg_file_list.extend(ifgs)
-
     if interferogram_network.reference_idx == 0:
         ifg_file_list.extend(single_ref_ifgs)
 
@@ -470,7 +460,7 @@ def create_ifgs(
     # If we requested max-bw-2 interferograms, we want
     # (1, 4), (1, 5), (4, 5), (4, 6), (5, 6)
     # (the same as though we had normal SLCs (1, 4, 5, 6) )
-    if interferogram_network.max_bandwidth is not None:
+    if interferogram_network.max_bandwidth is not None or interferogram_network.indexes:
         max_b = interferogram_network.max_bandwidth
         # Max bandwidth is easier: take the first `max_b` from `phase_linked_slcs`
         # (which are the (ref_date, ...) interferograms),...
@@ -479,6 +469,7 @@ def create_ifgs(
         network_rest = interferogram.Network(
             slc_list=phase_linked_slcs,
             max_bandwidth=max_b,
+            indexes=interferogram_network.indexes,
             outdir=ifg_dir,
             # Manually specify the dates, which come from the names of phase_linked_slcs
             dates=secondary_dates,

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -460,7 +460,27 @@ def create_ifgs(
     # If we requested max-bw-2 interferograms, we want
     # (1, 4), (1, 5), (4, 5), (4, 6), (5, 6)
     # (the same as though we had normal SLCs (1, 4, 5, 6) )
-    if interferogram_network.max_bandwidth is not None or interferogram_network.indexes:
+    if interferogram_network.indexes:
+        # TODO: if there are any (0, X) indexes, we need to pull from `single_ref_ifgs`
+        # ifgs_ref_date = single_ref_ifgs[:...]
+        network = interferogram.Network(
+            slc_list=phase_linked_slcs,
+            indexes=interferogram_network.indexes,
+            outdir=ifg_dir,
+            # Manually specify the dates, which come from the names of phase_linked_slcs
+            dates=secondary_dates,
+            write=not dry_run,
+            verify_slcs=not dry_run,
+        )
+        # Using `cast` to assert that the paths are not None
+        if len(network.ifg_list) == 0:
+            msg = "No interferograms were created"
+            raise ValueError(msg)
+        ifg_file_list = cast(list[Path], [ifg.path for ifg in network.ifg_list])
+        assert all(p is not None for p in ifg_file_list)
+        return ifg_file_list
+
+    if interferogram_network.max_bandwidth is not None:
         max_b = interferogram_network.max_bandwidth
         # Max bandwidth is easier: take the first `max_b` from `phase_linked_slcs`
         # (which are the (ref_date, ...) interferograms),...
@@ -478,7 +498,6 @@ def create_ifgs(
         )
         # Using `cast` to assert that the paths are not None
         ifgs_others = cast(list[Path], [ifg.path for ifg in network_rest.ifg_list])
-
         ifg_file_list.extend(ifgs_ref_date + ifgs_others)
 
     if interferogram_network.max_temporal_baseline is not None:

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -478,7 +478,6 @@ def create_ifgs(
             raise ValueError(msg)
         ifg_file_list = cast(list[Path], [ifg.path for ifg in network.ifg_list])
         assert all(p is not None for p in ifg_file_list)
-        return ifg_file_list
 
     if interferogram_network.max_bandwidth is not None:
         max_b = interferogram_network.max_bandwidth


### PR DESCRIPTION
Corner case of workflow relevant to DISP-S1:  https://github.com/opera-adt/disp-s1/pull/341
Forward mode passes `indexes`, but has compressed SLCs. This PR fixes that use case.