### PR TITLE
Add NISAR azimuth-block splitting for parallel full-frame processing

### DIFF
--- a/src/dolphin/io/_core.py
+++ b/src/dolphin/io/_core.py
@@ -302,6 +302,59 @@ def format_nc_filename(filename: Filename, ds_name: Optional[str] = None) -> str
     return f'{driver}:"{filename}":"//{ds_name.lstrip("/")}"'
 
 
+def _is_nisar_h5(filename: Filename) -> bool:
+    """Detect NISAR raw HDF5 by filename prefix (matches `format_nc_filename`)."""
+    s = str(filename)
+    return s.endswith(".h5") and Path(s).name.upper().startswith("NISAR_")
+
+
+def read_nisar_grid_metadata(
+    filename: Filename, subdataset: str
+) -> tuple[int, int, tuple[float, ...], int, str]:
+    """Read NISAR GSLC grid metadata via h5py.
+
+    NISAR's GSLC files store the projection in a sibling ``projection``
+    dataset and grid coordinates in ``xCoordinates`` / ``yCoordinates``
+    (cell centers) inside the same group as the polarization dataset.
+    GDAL's HDF5 driver doesn't expose any of this — it returns an
+    identity geotransform and empty projection — so the only reliable
+    path is to read it directly.
+
+    Honors the data dataset's ``grid_mapping`` attribute when present;
+    falls back to the conventional ``projection`` dataset name.
+
+    Returns ``(nx, ny, geotransform, epsg, projection_wkt)``.
+    """
+    from pathlib import PurePosixPath
+
+    from osgeo import osr
+
+    grid_path = str(PurePosixPath(subdataset).parent)
+    with h5py.File(str(filename), "r") as f:
+        dset = f[subdataset]
+        proj_name = dset.attrs.get("grid_mapping", "projection")
+        if isinstance(proj_name, bytes):
+            proj_name = proj_name.decode()
+        proj_raw = f[f"{grid_path}/{proj_name}"][()]
+        epsg = int(proj_raw.decode()) if isinstance(proj_raw, bytes) else int(proj_raw)
+        x_coords = f[f"{grid_path}/xCoordinates"][:]
+        y_coords = f[f"{grid_path}/yCoordinates"][:]
+        dx = float(f[f"{grid_path}/xCoordinateSpacing"][()])
+        dy = float(f[f"{grid_path}/yCoordinateSpacing"][()])
+    # Cell-center coords -> upper-left edge: back off half a pixel.
+    gt = (
+        float(x_coords[0]) - dx / 2.0,
+        dx,
+        0.0,
+        float(y_coords[0]) - dy / 2.0,
+        0.0,
+        dy,
+    )
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(epsg)
+    return len(x_coords), len(y_coords), gt, epsg, srs.ExportToWkt()
+
+
 def copy_projection(src_file: Filename, dst_file: Filename) -> None:
     """Copy projection/geotransform from `src_file` to `dst_file`."""
     ds_src = _get_gdal_ds(src_file)

--- a/src/dolphin/io/_core.py
+++ b/src/dolphin/io/_core.py
@@ -251,6 +251,18 @@ def format_nc_filename(filename: Filename, ds_name: Optional[str] = None) -> str
     If `filename` is already formatted, or if `filename` is not an HDF5/NetCDF
     file (based on the file extension), it is returned unchanged.
 
+    The driver prefix is chosen by filename:
+
+    - ``.nc``  → ``NETCDF:"file":"//ds"``
+    - ``.h5`` whose granule prefix is ``NISAR_`` → ``HDF5:"file":"//ds"``
+      (NISAR raw HDF5; no CF metadata, and GDAL's NETCDF driver refuses
+      it with "No such file or directory")
+    - every other ``.h5`` → ``NETCDF:"file":"//ds"``
+      (OPERA CSLCs, COMPASS CSLCs + static_layers, etc. ship CF-1.8-
+      compliant HDF5 and depend on the NETCDF driver to read the grid
+      mapping; the bare HDF5 driver opens the data but reports an
+      identity geotransform)
+
     Parameters
     ----------
     filename : str or PathLike
@@ -282,7 +294,12 @@ def format_nc_filename(filename: Filename, ds_name: Optional[str] = None) -> str
         msg = "Must provide dataset name for HDF5/NetCDF files"
         raise ValueError(msg)
 
-    return f'NETCDF:"{filename}":"//{ds_name.lstrip("/")}"'
+    basename = Path(fname_clean).name.upper()
+    if fname_clean.endswith(".h5") and basename.startswith("NISAR_"):
+        driver = "HDF5"
+    else:
+        driver = "NETCDF"
+    return f'{driver}:"{filename}":"//{ds_name.lstrip("/")}"'
 
 
 def copy_projection(src_file: Filename, dst_file: Filename) -> None:

--- a/src/dolphin/io/_readers.py
+++ b/src/dolphin/io/_readers.py
@@ -819,6 +819,27 @@ class VRTStack(StackReader):
         self.proj = ds.GetProjection()
         self.srs = ds.GetSpatialRef()
         ds = bnd1 = None
+
+        # GDAL's HDF5 driver doesn't read NISAR's CF grid_mapping, so the
+        # metadata above is identity GT + empty projection. Anything that
+        # rasterizes a real-world polygon onto this VRT (bounds_mask,
+        # nodata_mask, stitching crop) then silently produces an all-zero
+        # result. Patch from h5py for the NISAR case before writing the VRT.
+        if (
+            self.subdataset
+            and io._core._is_nisar_h5(self.file_list[0])
+            and self.gt == (0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+            and not self.proj
+        ):
+            from osgeo import osr
+
+            _, _, gt, _, wkt = io._core.read_nisar_grid_metadata(
+                self.file_list[0], self.subdataset
+            )
+            self.gt = gt
+            self.proj = wkt
+            self.srs = osr.SpatialReference()
+            self.srs.ImportFromWkt(wkt)
         # Save the subset info
 
         self.xoff, self.yoff = 0, 0

--- a/src/dolphin/workflows/_block_split.py
+++ b/src/dolphin/workflows/_block_split.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 from dolphin import io
@@ -72,85 +71,25 @@ class BlockBounds:
     epsg: int
 
 
-def _is_nisar_h5(filename: Filename) -> bool:
-    """Detect NISAR raw HDF5 by filename prefix (matches `format_nc_filename`)."""
-    s = str(filename)
-    return s.endswith(".h5") and Path(s).name.upper().startswith("NISAR_")
-
-
-def _gdal_path_for(cfg: DisplacementWorkflow) -> str:
-    """Build the GDAL-compatible URI for the first input file in `cfg`.
-
-    Uses ``dolphin.io.format_nc_filename`` so NISAR raw HDF5 (HDF5: driver),
-    OPERA CSLCs and other CF-compliant HDF5s (NETCDF: driver), and plain
-    GDAL-readable rasters all resolve correctly.
-    """
-    return io.format_nc_filename(cfg.cslc_file_list[0], cfg.input_options.subdataset)
-
-
-def _read_nisar_grid_metadata(
-    filename: Filename, subdataset: str
-) -> tuple[int, int, tuple[float, ...], int]:
-    """Read NISAR grid metadata via h5py.
-
-    NISAR's GSLC files store the projection in a sibling ``projection``
-    dataset and grid coordinates in ``xCoordinates`` / ``yCoordinates``
-    (cell centers) inside the same group as the polarization dataset.
-    GDAL's HDF5 driver doesn't expose any of this — it returns an identity
-    geotransform — so the only reliable path is to read it directly.
-
-    Returns ``(nx, ny, geotransform, epsg)``.
-    """
-    import h5py
-
-    grid_path = str(PurePosixPath(subdataset).parent)
-    with h5py.File(str(filename), "r") as f:
-        # Honor the CF-style ``grid_mapping`` attribute if present; fall back
-        # to the conventional ``projection`` name.
-        dset = f[subdataset]
-        proj_name = dset.attrs.get("grid_mapping", "projection")
-        if isinstance(proj_name, bytes):
-            proj_name = proj_name.decode()
-        proj_raw = f[f"{grid_path}/{proj_name}"][()]
-        epsg = int(proj_raw.decode()) if isinstance(proj_raw, bytes) else int(proj_raw)
-        x_coords = f[f"{grid_path}/xCoordinates"][:]
-        y_coords = f[f"{grid_path}/yCoordinates"][:]
-        dx = float(f[f"{grid_path}/xCoordinateSpacing"][()])
-        dy = float(f[f"{grid_path}/yCoordinateSpacing"][()])
-    # NISAR coords are cell centers; geotransform anchors at the upper-left
-    # cell *edge*, so back off half a pixel. dy is negative in standard
-    # north-up NISAR grids, so subtracting dy/2 raises ymax above the first
-    # row's center.
-    gt = (
-        float(x_coords[0]) - dx / 2.0,
-        dx,
-        0.0,
-        float(y_coords[0]) - dy / 2.0,
-        0.0,
-        dy,
-    )
-    nx, ny = len(x_coords), len(y_coords)
-    return nx, ny, gt, epsg
-
-
 def _read_grid_metadata(
     cfg: DisplacementWorkflow,
 ) -> tuple[int, int, tuple[float, ...], int]:
     """Return ``(nx, ny, geotransform, epsg)`` for the first input file.
 
-    NISAR raw HDF5: bypass GDAL and read from the grid group via h5py.
-    Everything else (.tif, OPERA CSLC .h5, .nc): route through dolphin.io
-    GDAL helpers and ``format_nc_filename``.
+    NISAR raw HDF5 reads via h5py because GDAL's HDF5 driver doesn't
+    expose the CF grid_mapping; everything else routes through the
+    ``dolphin.io`` GDAL helpers.
     """
     first = cfg.cslc_file_list[0]
-    if _is_nisar_h5(first):
+    if io._core._is_nisar_h5(first):
         # ``input_options.subdataset`` is required by the pydantic validator
-        # whenever any input is an .h5/.nc, so this assert is for mypy.
+        # for any .h5/.nc; assert is for mypy.
         subdataset = cfg.input_options.subdataset
         assert subdataset is not None
-        return _read_nisar_grid_metadata(first, subdataset)
+        nx, ny, gt, epsg, _ = io._core.read_nisar_grid_metadata(first, subdataset)
+        return nx, ny, gt, epsg
 
-    gdal_path = _gdal_path_for(cfg)
+    gdal_path = io.format_nc_filename(first, cfg.input_options.subdataset)
     try:
         crs = io.get_raster_crs(gdal_path)
         epsg = crs.to_epsg()

--- a/src/dolphin/workflows/_block_split.py
+++ b/src/dolphin/workflows/_block_split.py
@@ -1,0 +1,224 @@
+"""Split a single frame into synthetic azimuth-block "bursts".
+
+Used by ``displacement.py`` when the input does not match OPERA's burst
+naming convention (e.g. NISAR GSLCs, where there is one frame-sized file
+per acquisition rather than one file per Sentinel-1-style burst).
+
+Each block reuses the full input file list but applies its own
+``output_options.bounds`` to restrict spatial processing. The block-stitcher
+(``stitching_bursts.run``) then mosaics the per-block outputs the same way
+it mosaics real OPERA bursts.
+
+NOTE: each block here still uses a full-frame VRTStack and rasterizes a
+full-frame bounds mask (`wrapped_phase._get_mask`). EagerLoader skips
+fully-masked tiles, so I/O stays bounded — but per-block RAM and VRT-init
+time scale with the *full* frame, not the block. With N blocks x 20 GSLCs,
+that's also N copies of the same file handles open concurrently.
+
+A leaner alternative is a per-block **windowed sub-VRT** (gdal.Translate
+with srcWin=(0, y_off, nx, y_size), or exposing the SrcRect/DstRect hooks
+already present in VRTStack's XML template via a new `pixel_window` kwarg).
+That would:
+  - cut per-block RAM (no full-frame mask, no full-frame VRT)
+  - shave VRT init per block
+  - eliminate boundary-tile read waste at block edges
+
+The trade is a non-trivial refactor: VRTStack.shape / __getitem__ /
+slice_dates all assume the full frame, and downstream `like_filename`
+callers would now see a block-sized georef (which is what burst-stitching
+already wants). Deferred — bounds-based blocking is benchmarked first.
+
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from dolphin._types import Bbox
+
+if TYPE_CHECKING:
+    from .config import DisplacementWorkflow
+
+__all__ = ["split_frame_into_blocks"]
+
+logger = logging.getLogger(__name__)
+
+# ``displacement.run`` hardcodes ``stitching_bursts.run(corr_window_size=(11, 11))``
+# (see displacement.py). The halo on each block must cover its radius so that
+# stitching feathering uses non-edge-degraded data at block boundaries.
+_STITCHER_CORR_WINDOW_Y = 11
+
+# A few input rows of safety on top of the worst-case crop. Cheap insurance
+# against off-by-one alignment with strides / block_shape.
+_DEFAULT_HALO_SAFETY = 5
+
+
+def _open_for_bounds(first_file: str, subdataset: str | None):
+    """Open ``first_file`` (HDF5 subdataset if applicable) for georef inspection.
+
+    Returns the GDAL dataset; caller is responsible for releasing it.
+    """
+    from osgeo import gdal
+
+    gdal.UseExceptions()
+    path = f'NETCDF:"{first_file}":{subdataset}' if subdataset else str(first_file)
+    ds = gdal.Open(path)
+    if ds is None:
+        raise RuntimeError(f"Could not open {path}")
+    return ds
+
+
+def _min_halo_rows(cfg: DisplacementWorkflow) -> int:
+    """Compute the minimum halo (input rows) required for a safe block edge.
+
+    The block edge gets cropped by the worst of three windows. Two are in
+    strided/output coordinates, so they multiply by ``stride_y`` to come back
+    to input rows:
+
+        - half_window_y                                          (input rows)
+        - similarity_search_radius * stride_y                    (input rows)
+        - (corr_window_y // 2)     * stride_y                    (input rows)
+
+    A small safety margin is added so per-block outputs aren't cropped right
+    at the cover-zone edge.
+    """
+    half_window_y = cfg.phase_linking.half_window.y
+    # similarity_search_radius lives on PhaseLinkingOptions on the similarity
+    # branch but not on main; fall back to dolphin's default of 7 when absent.
+    sim_radius = getattr(cfg.phase_linking, "similarity_search_radius", 7)
+    stride_y = cfg.output_options.strides.y
+    return (
+        max(
+            half_window_y,
+            sim_radius * stride_y,
+            (_STITCHER_CORR_WINDOW_Y // 2) * stride_y,
+        )
+        + _DEFAULT_HALO_SAFETY
+    )
+
+
+def split_frame_into_blocks(
+    cfg: DisplacementWorkflow,
+    *,
+    num_blocks: int,
+    halo_rows: int | None = None,
+) -> dict[str, tuple[Bbox, int]]:
+    """Compute per-block (bounds, epsg) for synthetic NISAR-style bursts.
+
+    The frame is split in the **azimuth** (row) direction into ``num_blocks``
+    non-overlapping central regions; each region is padded on top and bottom
+    by ``halo_rows`` to give phase-linking / similarity / stitching room to
+    operate without edge artifacts.
+
+    Parameters
+    ----------
+    cfg
+        The full displacement workflow config. Used to read the first input
+        file's georeference, the subdataset path, the phase-linking
+        half-window, similarity search radius, and stride.
+    num_blocks
+        Number of azimuth blocks. Must be >= 1. When 1, the result is a
+        single full-frame entry with no halo.
+    halo_rows
+        Halo on each side of a block, in **input rows**. When ``None``,
+        defaults to ``max(half_window_y, similarity_search_radius * stride_y,
+        (corr_window_y // 2) * stride_y) + 3``.
+
+    Returns
+    -------
+    dict
+        Maps block id (``"block_00"``, ``"block_01"``, ...) to a pair
+        ``((xmin, ymin, xmax, ymax), epsg)`` suitable for assigning to a
+        per-block ``output_options.bounds`` / ``output_options.bounds_epsg``.
+
+    Raises
+    ------
+    ValueError
+        If ``num_blocks < 1`` or ``cfg.cslc_file_list`` is empty.
+    RuntimeError
+        If the first CSLC cannot be opened with GDAL.
+
+    """
+    if num_blocks < 1:
+        raise ValueError(f"num_blocks must be >= 1, got {num_blocks}")
+    if not cfg.cslc_file_list:
+        raise ValueError("cfg.cslc_file_list is empty; nothing to split")
+
+    halo = halo_rows if halo_rows is not None else _min_halo_rows(cfg)
+    if halo < 0:
+        raise ValueError(f"halo_rows must be >= 0, got {halo}")
+
+    from osgeo import osr
+
+    first_file = str(cfg.cslc_file_list[0])
+    subdataset = cfg.input_options.subdataset
+    ds = _open_for_bounds(first_file, subdataset)
+    try:
+        gt = ds.GetGeoTransform()
+        nx, ny = ds.RasterXSize, ds.RasterYSize
+        srs = osr.SpatialReference()
+        srs.ImportFromWkt(ds.GetProjection())
+        authority = srs.GetAttrValue("AUTHORITY", 1)
+        if authority is None:
+            raise RuntimeError(f"Could not read EPSG code from {first_file} projection")
+        epsg = int(authority)
+    finally:
+        ds = None  # release GDAL handle
+
+    xmin, ymax = gt[0], gt[3]
+    px_x, px_y = gt[1], abs(gt[5])
+    xmax = xmin + nx * px_x
+
+    if num_blocks == 1:
+        # Single block = full frame, no halo needed (no boundaries to feather).
+        return {
+            "block_00": (
+                Bbox(float(xmin), float(ymax - ny * px_y), float(xmax), float(ymax)),
+                epsg,
+            )
+        }
+
+    rows_per = ny // num_blocks
+    if rows_per <= 2 * halo:
+        # Halo would exceed the central region — caller should reduce blocks
+        # or halo. Refusing rather than silently producing degenerate blocks.
+        raise ValueError(
+            f"halo_rows={halo} too large for num_blocks={num_blocks} on a "
+            f"{ny}-row frame: each block's central region would be "
+            f"{rows_per} rows. Reduce num_blocks or pass halo_rows explicitly."
+        )
+
+    blocks: dict[str, tuple[Bbox, int]] = {}
+    for i in range(num_blocks):
+        cs = i * rows_per
+        ce = ny if i == num_blocks - 1 else (i + 1) * rows_per
+        rs = max(0, cs - halo)
+        re = min(ny, ce + halo)
+        block_ymax = ymax - rs * px_y
+        block_ymin = ymax - re * px_y
+        block_id = f"block_{i:02d}"
+        blocks[block_id] = (
+            Bbox(float(xmin), float(block_ymin), float(xmax), float(block_ymax)),
+            epsg,
+        )
+        logger.debug(
+            "%s: rows central=[%d, %d] read=[%d, %d] y=[%.0f, %.0f]",
+            block_id,
+            cs,
+            ce,
+            rs,
+            re,
+            block_ymin,
+            block_ymax,
+        )
+
+    logger.info(
+        "Split frame (%dx%d px, EPSG:%d) into %d azimuth blocks, halo=%d rows",
+        nx,
+        ny,
+        epsg,
+        num_blocks,
+        halo,
+    )
+    return blocks

--- a/src/dolphin/workflows/_block_split.py
+++ b/src/dolphin/workflows/_block_split.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 from dolphin import io
@@ -71,6 +72,12 @@ class BlockBounds:
     epsg: int
 
 
+def _is_nisar_h5(filename: Filename) -> bool:
+    """Detect NISAR raw HDF5 by filename prefix (matches `format_nc_filename`)."""
+    s = str(filename)
+    return s.endswith(".h5") and Path(s).name.upper().startswith("NISAR_")
+
+
 def _gdal_path_for(cfg: DisplacementWorkflow) -> str:
     """Build the GDAL-compatible URI for the first input file in `cfg`.
 
@@ -79,6 +86,90 @@ def _gdal_path_for(cfg: DisplacementWorkflow) -> str:
     GDAL-readable rasters all resolve correctly.
     """
     return io.format_nc_filename(cfg.cslc_file_list[0], cfg.input_options.subdataset)
+
+
+def _read_nisar_grid_metadata(
+    filename: Filename, subdataset: str
+) -> tuple[int, int, tuple[float, ...], int]:
+    """Read NISAR grid metadata via h5py.
+
+    NISAR's GSLC files store the projection in a sibling ``projection``
+    dataset and grid coordinates in ``xCoordinates`` / ``yCoordinates``
+    (cell centers) inside the same group as the polarization dataset.
+    GDAL's HDF5 driver doesn't expose any of this — it returns an identity
+    geotransform — so the only reliable path is to read it directly.
+
+    Returns ``(nx, ny, geotransform, epsg)``.
+    """
+    import h5py
+
+    grid_path = str(PurePosixPath(subdataset).parent)
+    with h5py.File(str(filename), "r") as f:
+        # Honor the CF-style ``grid_mapping`` attribute if present; fall back
+        # to the conventional ``projection`` name.
+        dset = f[subdataset]
+        proj_name = dset.attrs.get("grid_mapping", "projection")
+        if isinstance(proj_name, bytes):
+            proj_name = proj_name.decode()
+        proj_raw = f[f"{grid_path}/{proj_name}"][()]
+        epsg = int(proj_raw.decode()) if isinstance(proj_raw, bytes) else int(proj_raw)
+        x_coords = f[f"{grid_path}/xCoordinates"][:]
+        y_coords = f[f"{grid_path}/yCoordinates"][:]
+        dx = float(f[f"{grid_path}/xCoordinateSpacing"][()])
+        dy = float(f[f"{grid_path}/yCoordinateSpacing"][()])
+    # NISAR coords are cell centers; geotransform anchors at the upper-left
+    # cell *edge*, so back off half a pixel. dy is negative in standard
+    # north-up NISAR grids, so subtracting dy/2 raises ymax above the first
+    # row's center.
+    gt = (
+        float(x_coords[0]) - dx / 2.0,
+        dx,
+        0.0,
+        float(y_coords[0]) - dy / 2.0,
+        0.0,
+        dy,
+    )
+    nx, ny = len(x_coords), len(y_coords)
+    return nx, ny, gt, epsg
+
+
+def _read_grid_metadata(
+    cfg: DisplacementWorkflow,
+) -> tuple[int, int, tuple[float, ...], int]:
+    """Return ``(nx, ny, geotransform, epsg)`` for the first input file.
+
+    NISAR raw HDF5: bypass GDAL and read from the grid group via h5py.
+    Everything else (.tif, OPERA CSLC .h5, .nc): route through dolphin.io
+    GDAL helpers and ``format_nc_filename``.
+    """
+    first = cfg.cslc_file_list[0]
+    if _is_nisar_h5(first):
+        # ``input_options.subdataset`` is required by the pydantic validator
+        # whenever any input is an .h5/.nc, so this assert is for mypy.
+        subdataset = cfg.input_options.subdataset
+        assert subdataset is not None
+        return _read_nisar_grid_metadata(first, subdataset)
+
+    gdal_path = _gdal_path_for(cfg)
+    try:
+        crs = io.get_raster_crs(gdal_path)
+        epsg = crs.to_epsg()
+    except Exception as e:
+        msg = (
+            f"Could not read a usable EPSG from {gdal_path}; azimuth-block"
+            " splitting needs a geocoded input. Pass num_blocks=1 to skip,"
+            " or geocode the input frames first."
+        )
+        raise RuntimeError(msg) from e
+    if epsg is None:
+        msg = (
+            f"Input {gdal_path} has a projection but no EPSG authority code;"
+            " azimuth-block splitting needs an EPSG. Reproject the input first."
+        )
+        raise RuntimeError(msg)
+    nx, ny = io.get_raster_xysize(gdal_path)
+    gt = tuple(io.get_raster_gt(gdal_path))
+    return nx, ny, gt, epsg
 
 
 def _min_halo_rows(cfg: DisplacementWorkflow) -> int:
@@ -154,26 +245,7 @@ def split_frame_into_blocks(
     """
     halo = halo_rows if halo_rows is not None else _min_halo_rows(cfg)
 
-    gdal_path = _gdal_path_for(cfg)
-    try:
-        crs = io.get_raster_crs(gdal_path)
-        epsg = crs.to_epsg()
-    except Exception as e:
-        msg = (
-            f"Could not read a usable EPSG from {gdal_path}; azimuth-block"
-            " splitting needs a geocoded input. Pass num_blocks=1 to skip,"
-            " or geocode the input frames first."
-        )
-        raise RuntimeError(msg) from e
-    if epsg is None:
-        msg = (
-            f"Input {gdal_path} has a projection but no EPSG authority code;"
-            " azimuth-block splitting needs an EPSG. Reproject the input first."
-        )
-        raise RuntimeError(msg)
-
-    nx, ny = io.get_raster_xysize(gdal_path)
-    gt = io.get_raster_gt(gdal_path)
+    nx, ny, gt, epsg = _read_grid_metadata(cfg)
     xmin, ymax = gt[0], gt[3]
     px_x, px_y = gt[1], abs(gt[5])
     xmax = xmin + nx * px_x

--- a/src/dolphin/workflows/_block_split.py
+++ b/src/dolphin/workflows/_block_split.py
@@ -1,91 +1,103 @@
 """Split a single frame into synthetic azimuth-block "bursts".
 
-Used by ``displacement.py`` when the input does not match OPERA's burst
+Used by :mod:`displacement` when the input does not match OPERA's burst
 naming convention (e.g. NISAR GSLCs, where there is one frame-sized file
 per acquisition rather than one file per Sentinel-1-style burst).
 
-Each block reuses the full input file list but applies its own
-``output_options.bounds`` to restrict spatial processing. The block-stitcher
-(``stitching_bursts.run``) then mosaics the per-block outputs the same way
-it mosaics real OPERA bursts.
+Each block reuses the full input file list and runs phase linking over an
+expanded ``read_bounds`` rectangle (central rows + a row-direction halo).
+The halo gives phase linking, similarity, and SHP estimation enough
+neighborhood context that the **central** rows aren't edge-degraded.
+After phase linking completes, each block's stitching-bound output
+rasters are cropped to ``central_bounds`` (no halo) so adjacent blocks
+have disjoint extents. The block-stitcher then mosaics the per-block
+outputs without overlap, matching how OPERA bursts are stitched.
 
 NOTE: each block here still uses a full-frame VRTStack and rasterizes a
-full-frame bounds mask (`wrapped_phase._get_mask`). EagerLoader skips
-fully-masked tiles, so I/O stays bounded — but per-block RAM and VRT-init
-time scale with the *full* frame, not the block. With N blocks x 20 GSLCs,
-that's also N copies of the same file handles open concurrently.
-
-A leaner alternative is a per-block **windowed sub-VRT** (gdal.Translate
-with srcWin=(0, y_off, nx, y_size), or exposing the SrcRect/DstRect hooks
-already present in VRTStack's XML template via a new `pixel_window` kwarg).
-That would:
-  - cut per-block RAM (no full-frame mask, no full-frame VRT)
-  - shave VRT init per block
-  - eliminate boundary-tile read waste at block edges
-
-The trade is a non-trivial refactor: VRTStack.shape / __getitem__ /
-slice_dates all assume the full frame, and downstream `like_filename`
-callers would now see a block-sized georef (which is what burst-stitching
-already wants). Deferred — bounds-based blocking is benchmarked first.
-
+full-frame bounds mask. ``EagerLoader`` skips fully-masked tiles, so I/O
+stays bounded — but per-block RAM and VRT-init time scale with the
+*full* frame, not the block, and N parallel blocks open N copies of the
+same file handles concurrently. A leaner alternative is a per-block
+windowed sub-VRT; deferred until benchmarks justify the refactor.
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from dolphin._types import Bbox
+from dolphin import io
+from dolphin._types import Bbox, Filename
 
 if TYPE_CHECKING:
     from .config import DisplacementWorkflow
 
-__all__ = ["split_frame_into_blocks"]
+__all__ = ["BlockBounds", "split_frame_into_blocks"]
 
 logger = logging.getLogger(__name__)
 
-# ``displacement.run`` hardcodes ``stitching_bursts.run(corr_window_size=(11, 11))``
-# (see displacement.py). The halo on each block must cover its radius so that
-# stitching feathering uses non-edge-degraded data at block boundaries.
+# ``displacement.run`` hardcodes ``stitching_bursts.run(corr_window_size=(11, 11))``.
+# The halo must cover the y-radius of that window so post-stitch correlation
+# estimation has clean neighborhoods at block boundaries.
 _STITCHER_CORR_WINDOW_Y = 11
 
-# A few input rows of safety on top of the worst-case crop. Cheap insurance
-# against off-by-one alignment with strides / block_shape.
+# A few input rows of safety on top of the worst-case crop, to avoid cropping
+# right at the edge of where phase linking actually has valid context.
 _DEFAULT_HALO_SAFETY = 5
 
 
-def _open_for_bounds(first_file: str, subdataset: str | None):
-    """Open ``first_file`` (HDF5 subdataset if applicable) for georef inspection.
+@dataclass(frozen=True)
+class BlockBounds:
+    """Per-block bounds for an azimuth-split synthetic burst.
 
-    Returns the GDAL dataset; caller is responsible for releasing it.
+    Attributes
+    ----------
+    read_bounds
+        Bbox covering central rows plus a halo of input rows on top and
+        bottom. Passed to ``output_options.bounds`` so the per-block
+        phase-linking run sees the halo as valid input context.
+    central_bounds
+        Bbox covering only the central rows. After phase linking,
+        per-block stitching-bound outputs are cropped to this so
+        adjacent blocks have disjoint extents.
+    epsg
+        EPSG code of both bounds. Same as the input frame's CRS.
+
     """
-    from osgeo import gdal
 
-    gdal.UseExceptions()
-    path = f'NETCDF:"{first_file}":{subdataset}' if subdataset else str(first_file)
-    ds = gdal.Open(path)
-    if ds is None:
-        raise RuntimeError(f"Could not open {path}")
-    return ds
+    read_bounds: Bbox
+    central_bounds: Bbox
+    epsg: int
+
+
+def _gdal_path_for(cfg: DisplacementWorkflow) -> str:
+    """Build the GDAL-compatible URI for the first input file in `cfg`.
+
+    Uses ``dolphin.io.format_nc_filename`` so NISAR raw HDF5 (HDF5: driver),
+    OPERA CSLCs and other CF-compliant HDF5s (NETCDF: driver), and plain
+    GDAL-readable rasters all resolve correctly.
+    """
+    return io.format_nc_filename(cfg.cslc_file_list[0], cfg.input_options.subdataset)
 
 
 def _min_halo_rows(cfg: DisplacementWorkflow) -> int:
-    """Compute the minimum halo (input rows) required for a safe block edge.
+    """Minimum halo (input rows) for a safe block edge.
 
-    The block edge gets cropped by the worst of three windows. Two are in
-    strided/output coordinates, so they multiply by ``stride_y`` to come back
-    to input rows:
+    Three windows can crop the edge of phase-linking output. Two of them
+    are sized in strided/output coordinates, so they get multiplied by
+    ``stride_y`` to come back to input rows:
 
-        - half_window_y                                          (input rows)
-        - similarity_search_radius * stride_y                    (input rows)
-        - (corr_window_y // 2)     * stride_y                    (input rows)
+    - ``half_window_y``                            (input rows)
+    - ``similarity_search_radius * stride_y``      (input rows)
+    - ``(corr_window_y // 2) * stride_y``          (input rows)
 
-    A small safety margin is added so per-block outputs aren't cropped right
-    at the cover-zone edge.
+    A small safety margin keeps the central output away from the actual
+    cover-zone edge.
     """
     half_window_y = cfg.phase_linking.half_window.y
-    # similarity_search_radius lives on PhaseLinkingOptions on the similarity
-    # branch but not on main; fall back to dolphin's default of 7 when absent.
+    # similarity_search_radius lives on PhaseLinkingOptions on some branches
+    # but not on upstream main; fall back to dolphin's default of 7.
     sim_radius = getattr(cfg.phase_linking, "similarity_search_radius", 7)
     stride_y = cfg.output_options.strides.y
     return (
@@ -103,114 +115,111 @@ def split_frame_into_blocks(
     *,
     num_blocks: int,
     halo_rows: int | None = None,
-) -> dict[str, tuple[Bbox, int]]:
-    """Compute per-block (bounds, epsg) for synthetic NISAR-style bursts.
+) -> dict[str, BlockBounds]:
+    """Compute per-block read/central bounds for NISAR-style azimuth splitting.
 
-    The frame is split in the **azimuth** (row) direction into ``num_blocks``
-    non-overlapping central regions; each region is padded on top and bottom
-    by ``halo_rows`` to give phase-linking / similarity / stitching room to
-    operate without edge artifacts.
+    The frame is split in the azimuth (row) direction into ``num_blocks``
+    non-overlapping **central** regions. Each block is also given a halo
+    of ``halo_rows`` input rows on top and bottom; the halo is included
+    in ``read_bounds`` (so phase linking has clean neighborhood context
+    at the central edge) but excluded from ``central_bounds`` (so the
+    block's stitched extent is disjoint from neighbors').
 
     Parameters
     ----------
     cfg
-        The full displacement workflow config. Used to read the first input
-        file's georeference, the subdataset path, the phase-linking
-        half-window, similarity search radius, and stride.
+        Displacement workflow config. Reads the first input file's
+        georeference, the phase-linking half-window, the similarity
+        search radius (if present), and the stride.
     num_blocks
-        Number of azimuth blocks. Must be >= 1. When 1, the result is a
-        single full-frame entry with no halo.
+        Number of azimuth blocks (validated upstream by pydantic).
+        When 1, returns a single block with no halo.
     halo_rows
-        Halo on each side of a block, in **input rows**. When ``None``,
-        defaults to ``max(half_window_y, similarity_search_radius * stride_y,
-        (corr_window_y // 2) * stride_y) + 3``.
+        Halo on each side of a block, in input rows. ``None`` uses
+        :func:`_min_halo_rows`.
 
     Returns
     -------
-    dict
-        Maps block id (``"block_00"``, ``"block_01"``, ...) to a pair
-        ``((xmin, ymin, xmax, ymax), epsg)`` suitable for assigning to a
-        per-block ``output_options.bounds`` / ``output_options.bounds_epsg``.
+    dict[str, BlockBounds]
+        Maps ``"block_00"``, ``"block_01"``, ... to per-block bounds.
 
     Raises
     ------
     ValueError
-        If ``num_blocks < 1`` or ``cfg.cslc_file_list`` is empty.
+        If the central region would be smaller than ``2 * halo`` rows
+        (caller should reduce ``num_blocks`` or pass ``halo_rows``).
     RuntimeError
-        If the first CSLC cannot be opened with GDAL.
+        If the first input file has no usable projection.
 
     """
-    if num_blocks < 1:
-        raise ValueError(f"num_blocks must be >= 1, got {num_blocks}")
-    if not cfg.cslc_file_list:
-        raise ValueError("cfg.cslc_file_list is empty; nothing to split")
-
     halo = halo_rows if halo_rows is not None else _min_halo_rows(cfg)
-    if halo < 0:
-        raise ValueError(f"halo_rows must be >= 0, got {halo}")
 
-    from osgeo import osr
-
-    first_file = str(cfg.cslc_file_list[0])
-    subdataset = cfg.input_options.subdataset
-    ds = _open_for_bounds(first_file, subdataset)
+    gdal_path = _gdal_path_for(cfg)
     try:
-        gt = ds.GetGeoTransform()
-        nx, ny = ds.RasterXSize, ds.RasterYSize
-        srs = osr.SpatialReference()
-        srs.ImportFromWkt(ds.GetProjection())
-        authority = srs.GetAttrValue("AUTHORITY", 1)
-        if authority is None:
-            raise RuntimeError(f"Could not read EPSG code from {first_file} projection")
-        epsg = int(authority)
-    finally:
-        ds = None  # release GDAL handle
+        crs = io.get_raster_crs(gdal_path)
+        epsg = crs.to_epsg()
+    except Exception as e:
+        msg = (
+            f"Could not read a usable EPSG from {gdal_path}; azimuth-block"
+            " splitting needs a geocoded input. Pass num_blocks=1 to skip,"
+            " or geocode the input frames first."
+        )
+        raise RuntimeError(msg) from e
+    if epsg is None:
+        msg = (
+            f"Input {gdal_path} has a projection but no EPSG authority code;"
+            " azimuth-block splitting needs an EPSG. Reproject the input first."
+        )
+        raise RuntimeError(msg)
 
+    nx, ny = io.get_raster_xysize(gdal_path)
+    gt = io.get_raster_gt(gdal_path)
     xmin, ymax = gt[0], gt[3]
     px_x, px_y = gt[1], abs(gt[5])
     xmax = xmin + nx * px_x
 
     if num_blocks == 1:
-        # Single block = full frame, no halo needed (no boundaries to feather).
-        return {
-            "block_00": (
-                Bbox(float(xmin), float(ymax - ny * px_y), float(xmax), float(ymax)),
-                epsg,
-            )
-        }
+        full = Bbox(float(xmin), float(ymax - ny * px_y), float(xmax), float(ymax))
+        return {"block_00": BlockBounds(full, full, epsg)}
 
     rows_per = ny // num_blocks
     if rows_per <= 2 * halo:
-        # Halo would exceed the central region — caller should reduce blocks
-        # or halo. Refusing rather than silently producing degenerate blocks.
-        raise ValueError(
+        msg = (
             f"halo_rows={halo} too large for num_blocks={num_blocks} on a "
             f"{ny}-row frame: each block's central region would be "
             f"{rows_per} rows. Reduce num_blocks or pass halo_rows explicitly."
         )
+        raise ValueError(msg)
 
-    blocks: dict[str, tuple[Bbox, int]] = {}
+    blocks: dict[str, BlockBounds] = {}
     for i in range(num_blocks):
         cs = i * rows_per
         ce = ny if i == num_blocks - 1 else (i + 1) * rows_per
         rs = max(0, cs - halo)
         re = min(ny, ce + halo)
-        block_ymax = ymax - rs * px_y
-        block_ymin = ymax - re * px_y
-        block_id = f"block_{i:02d}"
-        blocks[block_id] = (
-            Bbox(float(xmin), float(block_ymin), float(xmax), float(block_ymax)),
-            epsg,
+        read_bbox = Bbox(
+            float(xmin),
+            float(ymax - re * px_y),
+            float(xmax),
+            float(ymax - rs * px_y),
         )
+        central_bbox = Bbox(
+            float(xmin),
+            float(ymax - ce * px_y),
+            float(xmax),
+            float(ymax - cs * px_y),
+        )
+        block_id = f"block_{i:02d}"
+        blocks[block_id] = BlockBounds(read_bbox, central_bbox, epsg)
         logger.debug(
-            "%s: rows central=[%d, %d] read=[%d, %d] y=[%.0f, %.0f]",
+            "%s: rows central=[%d, %d] read=[%d, %d] central_y=[%.0f, %.0f]",
             block_id,
             cs,
             ce,
             rs,
             re,
-            block_ymin,
-            block_ymax,
+            central_bbox.bottom,
+            central_bbox.top,
         )
 
     logger.info(
@@ -222,3 +231,38 @@ def split_frame_into_blocks(
         halo,
     )
     return blocks
+
+
+def crop_to_central(filename: Filename, central_bounds: Bbox) -> None:
+    """Crop a raster in place to ``central_bounds``.
+
+    Used post-phase-linking on each block's stitching-bound outputs so
+    adjacent blocks have disjoint extents.
+
+    Parameters
+    ----------
+    filename
+        Path to the raster. Driver is preserved (e.g. GTiff, VRT).
+    central_bounds
+        Bbox in the raster's CRS.
+
+    """
+    from pathlib import Path
+
+    from osgeo import gdal
+
+    gdal.UseExceptions()
+    src = Path(filename)
+    # Use a sibling temp path that keeps the same extension so GDAL infers
+    # the same driver. Insert ``.cropped`` before the extension.
+    tmp = src.with_name(src.stem + ".cropped" + src.suffix)
+    # projWin order: (ulx, uly, lrx, lry)
+    proj_win = (
+        central_bounds.left,
+        central_bounds.top,
+        central_bounds.right,
+        central_bounds.bottom,
+    )
+    gdal.Translate(str(tmp), str(src), projWin=proj_win)
+    src.unlink()
+    tmp.rename(src)

--- a/src/dolphin/workflows/_block_split.py
+++ b/src/dolphin/workflows/_block_split.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from dolphin import io
@@ -244,36 +245,55 @@ def split_frame_into_blocks(
     return blocks
 
 
-def crop_to_central(filename: Filename, central_bounds: Bbox) -> None:
-    """Crop a raster in place to ``central_bounds``.
+def crop_to_central(filename: Filename, central_bounds: Bbox) -> Path:
+    """Crop a raster to ``central_bounds`` and return the path of the result.
 
     Used post-phase-linking on each block's stitching-bound outputs so
     adjacent blocks have disjoint extents.
 
+    Always materializes to GTiff. For ``.tif`` inputs the result replaces
+    the original at the same path; for ``.vrt`` inputs the result is a
+    sibling ``.tif`` and the original ``.vrt`` is removed. Materializing
+    is necessary because ``gdal.Translate(out.vrt, src.vrt, projWin=...)``
+    writes a VRT whose ``<SourceFilename>`` is the input path — renaming
+    that output back over the source produces a self-referential VRT that
+    gdal_merge later rejects with "Recursion detected".
+
     Parameters
     ----------
     filename
-        Path to the raster. Driver is preserved (e.g. GTiff, VRT).
+        Path to the raster (``.tif`` or ``.vrt``).
     central_bounds
         Bbox in the raster's CRS.
 
-    """
-    from pathlib import Path
+    Returns
+    -------
+    Path
+        Path of the cropped raster. May differ from ``filename`` when the
+        input was a ``.vrt`` (extension becomes ``.tif``); callers should
+        substitute this back into their file lists.
 
+    """
     from osgeo import gdal
 
     gdal.UseExceptions()
     src = Path(filename)
-    # Use a sibling temp path that keeps the same extension so GDAL infers
-    # the same driver. Insert ``.cropped`` before the extension.
-    tmp = src.with_name(src.stem + ".cropped" + src.suffix)
-    # projWin order: (ulx, uly, lrx, lry)
     proj_win = (
         central_bounds.left,
         central_bounds.top,
         central_bounds.right,
         central_bounds.bottom,
     )
-    gdal.Translate(str(tmp), str(src), projWin=proj_win)
+    if src.suffix == ".tif":
+        # In-place rewrite via sibling temp; same path returned.
+        tmp = src.with_name(src.stem + ".cropped.tif")
+        gdal.Translate(str(tmp), str(src), projWin=proj_win, format="GTiff")
+        src.unlink()
+        tmp.rename(src)
+        return src
+    # VRT (or other virtual) input: materialize to a sibling .tif. The
+    # original is removed so there's no stale duplicate on disk.
+    dst = src.with_suffix(".tif")
+    gdal.Translate(str(dst), str(src), projWin=proj_win, format="GTiff")
     src.unlink()
-    tmp.rename(src)
+    return dst

--- a/src/dolphin/workflows/_utils.py
+++ b/src/dolphin/workflows/_utils.py
@@ -9,7 +9,7 @@ from typing import Mapping, Sequence
 
 from opera_utils import group_by_date
 
-from dolphin._types import Filename
+from dolphin._types import Bbox, Filename
 
 from .config import DisplacementWorkflow
 
@@ -23,6 +23,7 @@ def _create_burst_cfg(
     grouped_amp_mean_files: dict[str, list[Path]],
     grouped_amp_dispersion_files: dict[str, list[Path]],
     grouped_layover_shadow_mask_files: dict[str, list[Path]],
+    bounds: tuple[Bbox, int] | None = None,
 ) -> DisplacementWorkflow:
     cfg_temp_dict = cfg.model_dump(exclude={"cslc_file_list"})
 
@@ -35,6 +36,16 @@ def _create_burst_cfg(
     cfg_temp_dict["layover_shadow_mask_files"] = grouped_layover_shadow_mask_files[
         burst_id
     ]
+
+    # When splitting a single frame into synthetic "bursts" (NISAR
+    # block-as-burst via _block_split.split_frame_into_blocks), apply this
+    # block's spatial bounds. Real OPERA-burst runs pass bounds=None and
+    # inherit whatever the top-level cfg had.
+    if bounds is not None:
+        bbox, epsg = bounds
+        cfg_temp_dict["output_options"]["bounds"] = list(bbox)
+        cfg_temp_dict["output_options"]["bounds_epsg"] = epsg
+
     return DisplacementWorkflow(**cfg_temp_dict)
 
 

--- a/src/dolphin/workflows/_utils.py
+++ b/src/dolphin/workflows/_utils.py
@@ -5,13 +5,16 @@ import datetime
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import TYPE_CHECKING, Mapping, Sequence
 
 from opera_utils import group_by_date
 
-from dolphin._types import Bbox, Filename
+from dolphin._types import Filename
 
 from .config import DisplacementWorkflow
+
+if TYPE_CHECKING:
+    from ._block_split import BlockBounds
 
 logger = logging.getLogger("dolphin")
 
@@ -23,7 +26,7 @@ def _create_burst_cfg(
     grouped_amp_mean_files: dict[str, list[Path]],
     grouped_amp_dispersion_files: dict[str, list[Path]],
     grouped_layover_shadow_mask_files: dict[str, list[Path]],
-    bounds: tuple[Bbox, int] | None = None,
+    bounds: "BlockBounds | None" = None,
 ) -> DisplacementWorkflow:
     cfg_temp_dict = cfg.model_dump(exclude={"cslc_file_list"})
 
@@ -39,12 +42,14 @@ def _create_burst_cfg(
 
     # When splitting a single frame into synthetic "bursts" (NISAR
     # block-as-burst via _block_split.split_frame_into_blocks), apply this
-    # block's spatial bounds. Real OPERA-burst runs pass bounds=None and
-    # inherit whatever the top-level cfg had.
+    # block's read bounds. ``OutputOptions._check_and_convert_bounds`` rejects
+    # having both ``bounds`` and ``bounds_wkt`` set, so clear any top-level
+    # ``bounds_wkt`` here — the block bounds derived from the input frame are
+    # narrower than any top-level WKT could be.
     if bounds is not None:
-        bbox, epsg = bounds
-        cfg_temp_dict["output_options"]["bounds"] = list(bbox)
-        cfg_temp_dict["output_options"]["bounds_epsg"] = epsg
+        cfg_temp_dict["output_options"]["bounds"] = list(bounds.read_bounds)
+        cfg_temp_dict["output_options"]["bounds_epsg"] = bounds.epsg
+        cfg_temp_dict["output_options"]["bounds_wkt"] = None
 
     return DisplacementWorkflow(**cfg_temp_dict)
 

--- a/src/dolphin/workflows/_utils.py
+++ b/src/dolphin/workflows/_utils.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Mapping, Sequence
 
 from opera_utils import group_by_date
 
-from dolphin._types import Bbox, Filename
+from dolphin._types import Filename
 
 from .config import DisplacementWorkflow
 

--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -314,6 +314,23 @@ class InputOptions(BaseModel, extra="forbid"):
             " and sensor is not recognized, outputs remain in radians."
         ),
     )
+    azimuth_blocks: int = Field(
+        1,
+        description=(
+            "When the input does not match OPERA-burst naming (e.g. NISAR), split"
+            " each input frame into this many azimuth blocks and process each block"
+            " as a synthetic burst. Default 1 = no splitting."
+        ),
+        ge=1,
+    )
+    halo_rows: Optional[int] = Field(
+        None,
+        description=(
+            "Halo (input rows) on each side of an azimuth block. Default:"
+            " max(half_window_y, similarity_search_radius * stride_y,"
+            " (corr_window_y // 2) * stride_y) + 5."
+        ),
+    )
 
 
 class Strides(BaseModel, extra="forbid"):

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -167,6 +167,7 @@ class OutputPaths:
 def run(
     cfg: DisplacementWorkflow,
     debug: bool = False,
+    raise_on_empty: bool = True,
 ) -> OutputPaths:
     """Run the displacement workflow on a stack of SLCs.
 
@@ -177,6 +178,11 @@ def run(
         for controlling the workflow.
     debug : bool, optional
         Enable debug logging, by default False.
+    raise_on_empty : bool
+        If True, raises a `MaskingError` on the creation of a mask file with
+        no valid pixels.
+        Otherwise, raises a warning.
+        Default is True.
 
     """
     if cfg.log_file is None:
@@ -262,6 +268,7 @@ def run(
                 burst_cfg,
                 debug=debug,
                 max_workers=workers_per_burst,
+                raise_on_empty=raise_on_empty,
                 tqdm_kwargs={
                     "position": i,
                 },

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -10,21 +10,36 @@ from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from opera_utils import group_by_burst
 from tqdm.auto import tqdm
 
 from dolphin import __version__, timeseries, utils
 from dolphin._log import log_runtime, setup_logging
-from dolphin._types import Bbox
 from dolphin.timeseries import ReferencePoint
 
 from . import stitching_bursts, unwrapping, wrapped_phase
-from ._block_split import split_frame_into_blocks
+from ._block_split import BlockBounds, crop_to_central, split_frame_into_blocks
 from ._utils import _create_burst_cfg, _remove_dir_if_empty
 from .config import DisplacementWorkflow
 
 logger = logging.getLogger("dolphin")
+
+
+def _worker_init(tqdm_lock: Any, disable_hdf5_locking: bool) -> None:
+    """Initialize a wrapped-phase ProcessPoolExecutor worker process.
+
+    Sets the shared tqdm lock and, when ``disable_hdf5_locking`` is True,
+    disables HDF5 file locking in this child process. The HDF5 env var only
+    matters for the worker that opens the files, so setting it here keeps
+    the parent process's env clean (libraries imported in the parent that
+    cached the env value at import time won't be surprised by a mutated
+    parent env).
+    """
+    tqdm.set_lock(tqdm_lock)
+    if disable_hdf5_locking:
+        os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 
 
 @dataclass
@@ -42,7 +57,7 @@ class _GroupedInputs:
 
     is_opera_burst_mode: bool
     grouped_slc_files: dict[str, list[Path]]
-    block_bounds: dict[str, tuple[Bbox, int]]
+    block_bounds: dict[str, BlockBounds]
     grouped_amp_dispersion_files: dict[str, list[Path]]
     grouped_amp_mean_files: dict[str, list[Path]]
     grouped_layover_shadow_mask_files: dict[str, list[Path]]
@@ -70,7 +85,7 @@ def _prepare_grouped_inputs(cfg: DisplacementWorkflow) -> _GroupedInputs:
     is_opera_burst_mode = True
     try:
         grouped_slc_files = group_by_burst(cfg.cslc_file_list)
-        block_bounds: dict[str, tuple[Bbox, int]] = {}
+        block_bounds: dict[str, BlockBounds] = {}
     except ValueError as e:
         if "Could not parse burst id" not in str(e):
             raise
@@ -179,11 +194,6 @@ def run(
     num_parallel = min(
         cfg.worker_settings.n_parallel_bursts, len(grouped.grouped_slc_files)
     )
-    if not grouped.is_opera_burst_mode and num_parallel > 1:
-        # Multiple workers read the same NISAR GSLC (HDF5) files at different
-        # spatial extents. Disable HDF5 file locking to prevent hangs on
-        # NFS/Lustre filesystems where concurrent readers would otherwise block.
-        os.environ.setdefault("HDF5_USE_FILE_LOCKING", "FALSE")
     grouped_slc_files = grouped.grouped_slc_files
     block_bounds = grouped.block_bounds
     grouped_amp_dispersion_files = grouped.grouped_amp_dispersion_files
@@ -229,18 +239,22 @@ def run(
     # Now for each burst, run the wrapped phase estimation
     # Try running several bursts in parallel...
     # Use the Dummy one if not going parallel, as debugging is much simpler
-    num_workers = cfg.worker_settings.n_parallel_bursts
     Executor = (
         ProcessPoolExecutor if num_parallel > 1 else utils.DummyProcessPoolExecutor
     )
-    workers_per_burst = num_workers // num_parallel
+    workers_per_burst = cfg.worker_settings.n_parallel_bursts // num_parallel
     ctx = mp.get_context("spawn")
     tqdm.set_lock(ctx.RLock())
+    # When azimuth-block-as-burst is active and we have >1 parallel worker,
+    # multiple processes read the same NISAR HDF5 files at different spatial
+    # extents. Disable HDF5 file locking in each worker (not the parent) so
+    # concurrent readers don't block on NFS/Lustre flock.
+    needs_hdf5_unlock = not grouped.is_opera_burst_mode and num_parallel > 1
     with Executor(
-        max_workers=num_workers,
+        max_workers=cfg.worker_settings.n_parallel_bursts,
         mp_context=ctx,
-        initializer=tqdm.set_lock,
-        initargs=(tqdm.get_lock(),),
+        initializer=_worker_init,
+        initargs=(tqdm.get_lock(), needs_hdf5_unlock),
     ) as exc:
         fut_to_burst = {
             exc.submit(
@@ -267,6 +281,26 @@ def run(
                 shp_count_files,
                 similarity_files,
             ) = wrapped_phase_output
+
+            # If this burst is a synthetic azimuth block, the per-block outputs
+            # cover central rows + a halo. Crop the stitching-bound rasters
+            # down to central_bounds so adjacent blocks have disjoint extents
+            # and the stitcher doesn't have to pick a winner in the halo
+            # overlap. comp_slcs stay full-extent — they feed back into this
+            # block's next ministack and need to match its read bounds.
+            bb = block_bounds.get(burst)
+            if bb is not None and bb.read_bounds != bb.central_bounds:
+                for f in (
+                    list(cur_ifg_list)
+                    + list(cur_crlb_files)
+                    + list(cur_closure_phase_files)
+                    + list(temp_coh_files)
+                    + list(shp_count_files)
+                    + list(similarity_files)
+                    + [ps_file, amp_disp_file]
+                ):
+                    crop_to_central(f, bb.central_bounds)
+
             ifg_file_list.extend(cur_ifg_list)
             crlb_files.extend(cur_crlb_files)
             closure_phase_files.extend(cur_closure_phase_files)

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -15,13 +15,100 @@ from tqdm.auto import tqdm
 
 from dolphin import __version__, timeseries, utils
 from dolphin._log import log_runtime, setup_logging
+from dolphin._types import Bbox
 from dolphin.timeseries import ReferencePoint
 
 from . import stitching_bursts, unwrapping, wrapped_phase
+from ._block_split import split_frame_into_blocks
 from ._utils import _create_burst_cfg, _remove_dir_if_empty
 from .config import DisplacementWorkflow
 
 logger = logging.getLogger("dolphin")
+
+
+@dataclass
+class _GroupedInputs:
+    """Per-burst input file groupings + per-block bounds.
+
+    Built once at the top of :func:`run` by :func:`_prepare_grouped_inputs`.
+    Each ``grouped_*`` dict maps a burst id — either a real OPERA burst id
+    (``"t087_185678_iw2"``) or a synthetic NISAR block id
+    (``"block_00"`` / ``"phase_linking"``) — to that unit's file list.
+
+    ``block_bounds`` is non-empty only when NISAR-style inputs were split
+    into multiple azimuth blocks via ``cfg.input_options.azimuth_blocks``.
+    """
+
+    is_opera_burst_mode: bool
+    grouped_slc_files: dict[str, list[Path]]
+    block_bounds: dict[str, tuple[Bbox, int]]
+    grouped_amp_dispersion_files: dict[str, list[Path]]
+    grouped_amp_mean_files: dict[str, list[Path]]
+    grouped_layover_shadow_mask_files: dict[str, list[Path]]
+
+
+def _prepare_grouped_inputs(cfg: DisplacementWorkflow) -> _GroupedInputs:
+    """Detect input mode and group all file lists into per-burst dicts.
+
+    Tries OPERA's ``group_by_burst`` first. If the CSLC filenames don't carry
+    OPERA burst ids (e.g. NISAR GSLCs), falls back to one of two non-OPERA
+    paths:
+
+    1. ``azimuth_blocks > 1`` — splits the single frame into N synthetic
+       blocks via :func:`split_frame_into_blocks`. Each block reuses the full
+       CSLC list and gets per-block ``output_options.bounds`` (returned in
+       ``block_bounds``).
+    2. ``azimuth_blocks == 1`` — keeps the full frame as a single "burst"
+       under the key ``"phase_linking"``, no bounds.
+
+    Optional file lists (amp_disp, amp_mean, layover_shadow) are grouped by
+    burst in OPERA mode or broadcast to every key in non-OPERA mode. The
+    bounds mask inside ``wrapped_phase._get_mask`` clips them per block
+    automatically when bounds are set.
+    """
+    is_opera_burst_mode = True
+    try:
+        grouped_slc_files = group_by_burst(cfg.cslc_file_list)
+        block_bounds: dict[str, tuple[Bbox, int]] = {}
+    except ValueError as e:
+        if "Could not parse burst id" not in str(e):
+            raise
+        # Non-OPERA-burst inputs (e.g. NISAR full-frame GSLCs).
+        is_opera_burst_mode = False
+        if cfg.input_options.azimuth_blocks > 1:
+            # Split the single frame into N synthetic "bursts" for parallelism.
+            block_bounds = split_frame_into_blocks(
+                cfg,
+                num_blocks=cfg.input_options.azimuth_blocks,
+                halo_rows=cfg.input_options.halo_rows,
+            )
+            grouped_slc_files = dict.fromkeys(block_bounds, cfg.cslc_file_list)
+        else:
+            # Full-frame run: a single "burst" containing all inputs.
+            grouped_slc_files = {"phase_linking": cfg.cslc_file_list}
+            block_bounds = {}
+
+    def _group_or_broadcast(
+        files: list[Path] | None,
+    ) -> dict[str, list[Path]]:
+        if not files:
+            return defaultdict(list)
+        if is_opera_burst_mode:
+            return group_by_burst(files)
+        return {key: list(files) for key in grouped_slc_files}
+
+    return _GroupedInputs(
+        is_opera_burst_mode=is_opera_burst_mode,
+        grouped_slc_files=grouped_slc_files,
+        block_bounds=block_bounds,
+        grouped_amp_dispersion_files=_group_or_broadcast(
+            cfg.amplitude_dispersion_files
+        ),
+        grouped_amp_mean_files=_group_or_broadcast(cfg.amplitude_mean_files),
+        grouped_layover_shadow_mask_files=_group_or_broadcast(
+            cfg.layover_shadow_mask_files
+        ),
+    )
 
 
 @dataclass
@@ -87,29 +174,12 @@ def run(
         utils.disable_gpu()
     utils.set_num_threads(cfg.worker_settings.threads_per_worker)
 
-    try:
-        grouped_slc_files = group_by_burst(cfg.cslc_file_list)
-    except ValueError as e:
-        # Make sure it's not some other ValueError
-        if "Could not parse burst id" not in str(e):
-            raise
-        # Otherwise, we have SLC files which are not OPERA burst files
-        grouped_slc_files = {"phase_linking": cfg.cslc_file_list}
-
-    if cfg.amplitude_dispersion_files:
-        grouped_amp_dispersion_files = group_by_burst(cfg.amplitude_dispersion_files)
-    else:
-        grouped_amp_dispersion_files = defaultdict(list)
-    if cfg.amplitude_mean_files:
-        grouped_amp_mean_files = group_by_burst(cfg.amplitude_mean_files)
-    else:
-        grouped_amp_mean_files = defaultdict(list)
-    if cfg.layover_shadow_mask_files:
-        grouped_layover_shadow_mask_files = group_by_burst(
-            cfg.layover_shadow_mask_files
-        )
-    else:
-        grouped_layover_shadow_mask_files = defaultdict(list)
+    grouped = _prepare_grouped_inputs(cfg)
+    grouped_slc_files = grouped.grouped_slc_files
+    block_bounds = grouped.block_bounds
+    grouped_amp_dispersion_files = grouped.grouped_amp_dispersion_files
+    grouped_amp_mean_files = grouped.grouped_amp_mean_files
+    grouped_layover_shadow_mask_files = grouped.grouped_layover_shadow_mask_files
 
     # ######################################
     # 1. Burst-wise Wrapped phase estimation
@@ -125,6 +195,7 @@ def run(
                 grouped_amp_mean_files,
                 grouped_amp_dispersion_files,
                 grouped_layover_shadow_mask_files,
+                bounds=block_bounds.get(burst),
             ),
         )
         for burst in grouped_slc_files

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -288,18 +288,21 @@ def run(
             # and the stitcher doesn't have to pick a winner in the halo
             # overlap. comp_slcs stay full-extent — they feed back into this
             # block's next ministack and need to match its read bounds.
+            # crop_to_central may change a path's extension (.vrt -> .tif),
+            # so substitute the returned paths back in.
             bb = block_bounds.get(burst)
             if bb is not None and bb.read_bounds != bb.central_bounds:
-                for f in (
-                    list(cur_ifg_list)
-                    + list(cur_crlb_files)
-                    + list(cur_closure_phase_files)
-                    + list(temp_coh_files)
-                    + list(shp_count_files)
-                    + list(similarity_files)
-                    + [ps_file, amp_disp_file]
-                ):
-                    crop_to_central(f, bb.central_bounds)
+                cb = bb.central_bounds
+                cur_ifg_list = [crop_to_central(f, cb) for f in cur_ifg_list]
+                cur_crlb_files = [crop_to_central(f, cb) for f in cur_crlb_files]
+                cur_closure_phase_files = [
+                    crop_to_central(f, cb) for f in cur_closure_phase_files
+                ]
+                temp_coh_files = [crop_to_central(f, cb) for f in temp_coh_files]
+                shp_count_files = [crop_to_central(f, cb) for f in shp_count_files]
+                similarity_files = [crop_to_central(f, cb) for f in similarity_files]
+                ps_file = crop_to_central(ps_file, cb)
+                amp_disp_file = crop_to_central(amp_disp_file, cb)
 
             ifg_file_list.extend(cur_ifg_list)
             crlb_files.extend(cur_crlb_files)

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -17,7 +17,6 @@ from tqdm.auto import tqdm
 
 from dolphin import __version__, timeseries, utils
 from dolphin._log import log_runtime, setup_logging
-from dolphin._types import Bbox
 from dolphin.timeseries import ReferencePoint
 
 from . import stitching_bursts, unwrapping, wrapped_phase
@@ -87,91 +86,6 @@ def _prepare_grouped_inputs(cfg: DisplacementWorkflow) -> _GroupedInputs:
     try:
         grouped_slc_files = group_by_burst(cfg.cslc_file_list)
         block_bounds: dict[str, BlockBounds] = {}
-    except ValueError as e:
-        if "Could not parse burst id" not in str(e):
-            raise
-        # Non-OPERA-burst inputs (e.g. NISAR full-frame GSLCs).
-        is_opera_burst_mode = False
-        if cfg.input_options.azimuth_blocks > 1:
-            # Split the single frame into N synthetic "bursts" for parallelism.
-            block_bounds = split_frame_into_blocks(
-                cfg,
-                num_blocks=cfg.input_options.azimuth_blocks,
-                halo_rows=cfg.input_options.halo_rows,
-            )
-            grouped_slc_files = dict.fromkeys(block_bounds, cfg.cslc_file_list)
-        else:
-            # Full-frame run: a single "burst" containing all inputs.
-            grouped_slc_files = {"phase_linking": cfg.cslc_file_list}
-            block_bounds = {}
-
-    def _group_or_broadcast(
-        files: list[Path] | None,
-    ) -> dict[str, list[Path]]:
-        if not files:
-            return defaultdict(list)
-        if is_opera_burst_mode:
-            return group_by_burst(files)
-        return {key: list(files) for key in grouped_slc_files}
-
-    return _GroupedInputs(
-        is_opera_burst_mode=is_opera_burst_mode,
-        grouped_slc_files=grouped_slc_files,
-        block_bounds=block_bounds,
-        grouped_amp_dispersion_files=_group_or_broadcast(
-            cfg.amplitude_dispersion_files
-        ),
-        grouped_amp_mean_files=_group_or_broadcast(cfg.amplitude_mean_files),
-        grouped_layover_shadow_mask_files=_group_or_broadcast(
-            cfg.layover_shadow_mask_files
-        ),
-    )
-
-
-@dataclass
-class _GroupedInputs:
-    """Per-burst input file groupings + per-block bounds.
-
-    Built once at the top of :func:`run` by :func:`_prepare_grouped_inputs`.
-    Each ``grouped_*`` dict maps a burst id — either a real OPERA burst id
-    (``"t087_185678_iw2"``) or a synthetic NISAR block id
-    (``"block_00"`` / ``"phase_linking"``) — to that unit's file list.
-
-    ``block_bounds`` is non-empty only when NISAR-style inputs were split
-    into multiple azimuth blocks via ``cfg.input_options.azimuth_blocks``.
-    """
-
-    is_opera_burst_mode: bool
-    grouped_slc_files: dict[str, list[Path]]
-    block_bounds: dict[str, tuple[Bbox, int]]
-    grouped_amp_dispersion_files: dict[str, list[Path]]
-    grouped_amp_mean_files: dict[str, list[Path]]
-    grouped_layover_shadow_mask_files: dict[str, list[Path]]
-
-
-def _prepare_grouped_inputs(cfg: DisplacementWorkflow) -> _GroupedInputs:
-    """Detect input mode and group all file lists into per-burst dicts.
-
-    Tries OPERA's ``group_by_burst`` first. If the CSLC filenames don't carry
-    OPERA burst ids (e.g. NISAR GSLCs), falls back to one of two non-OPERA
-    paths:
-
-    1. ``azimuth_blocks > 1`` — splits the single frame into N synthetic
-       blocks via :func:`split_frame_into_blocks`. Each block reuses the full
-       CSLC list and gets per-block ``output_options.bounds`` (returned in
-       ``block_bounds``).
-    2. ``azimuth_blocks == 1`` — keeps the full frame as a single "burst"
-       under the key ``"phase_linking"``, no bounds.
-
-    Optional file lists (amp_disp, amp_mean, layover_shadow) are grouped by
-    burst in OPERA mode or broadcast to every key in non-OPERA mode. The
-    bounds mask inside ``wrapped_phase._get_mask`` clips them per block
-    automatically when bounds are set.
-    """
-    is_opera_burst_mode = True
-    try:
-        grouped_slc_files = group_by_burst(cfg.cslc_file_list)
-        block_bounds: dict[str, tuple[Bbox, int]] = {}
     except ValueError as e:
         if "Could not parse burst id" not in str(e):
             raise

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -5,6 +5,7 @@ import logging
 
 # import contextlib
 import multiprocessing as mp
+import os
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
@@ -175,6 +176,14 @@ def run(
     utils.set_num_threads(cfg.worker_settings.threads_per_worker)
 
     grouped = _prepare_grouped_inputs(cfg)
+    num_parallel = min(
+        cfg.worker_settings.n_parallel_bursts, len(grouped.grouped_slc_files)
+    )
+    if not grouped.is_opera_burst_mode and num_parallel > 1:
+        # Multiple workers read the same NISAR GSLC (HDF5) files at different
+        # spatial extents. Disable HDF5 file locking to prevent hangs on
+        # NFS/Lustre filesystems where concurrent readers would otherwise block.
+        os.environ.setdefault("HDF5_USE_FILE_LOCKING", "FALSE")
     grouped_slc_files = grouped.grouped_slc_files
     block_bounds = grouped.block_bounds
     grouped_amp_dispersion_files = grouped.grouped_amp_dispersion_files
@@ -221,7 +230,6 @@ def run(
     # Try running several bursts in parallel...
     # Use the Dummy one if not going parallel, as debugging is much simpler
     num_workers = cfg.worker_settings.n_parallel_bursts
-    num_parallel = min(num_workers, len(grouped_slc_files))
     Executor = (
         ProcessPoolExecutor if num_parallel > 1 else utils.DummyProcessPoolExecutor
     )

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -71,6 +71,7 @@ def run(
     cfg: DisplacementWorkflow,
     debug: bool = False,
     max_workers: int = 1,
+    raise_on_empty: bool = True,
     tqdm_kwargs=None,
 ) -> WrappedPhaseOutput:
     """Run the displacement workflow on a stack of SLCs.
@@ -84,6 +85,11 @@ def run(
         Enable debug logging, by default False.
     max_workers : int, optional
         Number of workers to use to process blocks during phase linking, by default 1.
+    raise_on_empty : bool
+        If True, raises a `MaskingError` on the creation of a mask file with
+        no valid pixels.
+        Otherwise, raises a warning.
+        Default is True.
     tqdm_kwargs : dict, optional
         dict of arguments to pass to `tqdm` (e.g. `position=n` for n parallel bars)
         See https://tqdm.github.io/docs/tqdm/#tqdm-objects for all options.
@@ -135,6 +141,7 @@ def run(
         layover_shadow_mask=layover_shadow_mask,
         cslc_file_list=non_compressed_slcs,
         subdataset=subdataset,
+        raise_on_empty=raise_on_empty,
     )
 
     nodata_mask = masking.load_mask_as_numpy(mask_filename) if mask_filename else None
@@ -547,6 +554,7 @@ def _get_mask(
     layover_shadow_mask: Filename | None,
     cslc_file_list: Sequence[Filename],
     subdataset: str | None = None,
+    raise_on_empty: bool = True,
 ) -> Path | None:
     # Make the nodata mask from the polygons, if we're using OPERA CSLCs
     mask_files: list[Path] = []
@@ -590,6 +598,7 @@ def _get_mask(
             mask_files=mask_files,
             output_file=combined_mask_filename,
             output_convention=masking.MaskConvention.ZERO_IS_NODATA,
+            raise_on_empty=raise_on_empty,
         )
     return combined_mask_filename
 

--- a/tests/test_workflows_block_split.py
+++ b/tests/test_workflows_block_split.py
@@ -151,16 +151,46 @@ def test_crop_to_central_replaces_in_place(dated_geotiff, tmp_path):
     # Copy frame to a sibling, then crop in-place
     target = tmp_path / "to_crop.tif"
     gdal.Translate(str(target), str(dated_geotiff))
-    crop_to_central(target, bb.central_bounds)
+    out = crop_to_central(target, bb.central_bounds)
 
+    assert out == target  # TIF input → same path returned
     ds = gdal.Open(str(target))
     expected_ny = round((bb.central_bounds.top - bb.central_bounds.bottom) / 30)
     assert ds.RasterYSize == expected_ny
     assert ds.RasterXSize == 1000  # x extent unchanged
-    # Same path retained
-    assert target.exists()
     # No stray .cropped sibling
     assert not (tmp_path / "to_crop.cropped.tif").exists()
+
+
+def test_crop_to_central_materializes_vrt(dated_geotiff, tmp_path):
+    """Cropping a .vrt materializes to a sibling .tif; original .vrt is removed.
+
+    Regression test for ``RuntimeError: Recursion detected`` from gdal_merge:
+    ``gdal.Translate`` on a ``.vrt`` input emits a VRT whose
+    ``<SourceFilename>`` is the input path, so renaming it back over the
+    source produces a self-referential VRT.
+    """
+    cfg = _make_cfg(dated_geotiff, tmp_path)
+    blocks = split_frame_into_blocks(cfg, num_blocks=3)
+    bb = blocks["block_01"]
+
+    # Build a VRT that points at the source GeoTIFF (mirrors how dolphin's
+    # virtual interferograms are structured).
+    vrt = tmp_path / "to_crop.vrt"
+    gdal.Translate(str(vrt), str(dated_geotiff), format="VRT")
+
+    out = crop_to_central(vrt, bb.central_bounds)
+
+    # Materialized to a sibling .tif at a new path
+    assert out == tmp_path / "to_crop.tif"
+    assert out.exists()
+    assert not vrt.exists()  # original .vrt removed
+
+    # And the output is openable as a non-recursive GTiff at the central extent
+    ds = gdal.Open(str(out))
+    assert ds.GetDriver().ShortName == "GTiff"
+    expected_ny = round((bb.central_bounds.top - bb.central_bounds.bottom) / 30)
+    assert ds.RasterYSize == expected_ny
 
 
 def test_block_bounds_dataclass_immutable():

--- a/tests/test_workflows_block_split.py
+++ b/tests/test_workflows_block_split.py
@@ -6,6 +6,8 @@ import dataclasses
 import itertools
 from pathlib import Path
 
+import h5py
+import numpy as np
 import pytest
 from osgeo import gdal, osr
 
@@ -13,6 +15,7 @@ from dolphin._types import Bbox
 from dolphin.workflows._block_split import (
     BlockBounds,
     _min_halo_rows,
+    _read_grid_metadata,
     crop_to_central,
     split_frame_into_blocks,
 )
@@ -168,3 +171,62 @@ def test_block_bounds_dataclass_immutable():
     )
     with pytest.raises(dataclasses.FrozenInstanceError):
         bb.epsg = 32610  # type: ignore[misc]
+
+
+def _make_nisar_h5(path: Path, *, nx: int = 100, ny: int = 200, epsg: int = 32637):
+    """Build a minimal NISAR-shaped HDF5 with the projection + coord datasets.
+
+    Mirrors the layout dolphin reads: ``/science/LSAR/GSLC/grids/frequencyA/{HH,
+    projection, xCoordinates, yCoordinates, x/yCoordinateSpacing}``.
+    """
+    dx, dy = 10.0, -5.0
+    x0, y0 = 500000.0, 1500000.0
+    with h5py.File(path, "w") as f:
+        g = f.create_group("/science/LSAR/GSLC/grids/frequencyA")
+        hh = g.create_dataset("HH", shape=(ny, nx), dtype=np.complex64)
+        hh.attrs["grid_mapping"] = np.bytes_(b"projection")
+        g.create_dataset("projection", data=np.uint32(epsg))
+        g.create_dataset(
+            "xCoordinates", data=x0 + dx * np.arange(nx) + dx / 2.0, dtype="float64"
+        )
+        g.create_dataset(
+            "yCoordinates", data=y0 + dy * np.arange(ny) + dy / 2.0, dtype="float64"
+        )
+        g.create_dataset("xCoordinateSpacing", data=dx)
+        g.create_dataset("yCoordinateSpacing", data=dy)
+
+
+def test_nisar_metadata_read_via_h5py(tmp_path):
+    fn = tmp_path / "NISAR_L2_PR_GSLC_001_X_20250101_001.h5"
+    _make_nisar_h5(fn, nx=100, ny=200, epsg=32637)
+    cfg = DisplacementWorkflow(
+        cslc_file_list=[fn],
+        work_directory=tmp_path,
+        input_options={"subdataset": "/science/LSAR/GSLC/grids/frequencyA/HH"},
+    )
+    nx, ny, gt, epsg = _read_grid_metadata(cfg)
+    assert (nx, ny, epsg) == (100, 200, 32637)
+    # cell-center -> UL-edge anchoring
+    assert gt[0] == 500000.0
+    assert gt[1] == 10.0
+    assert gt[3] == 1500000.0  # y0 = y_coord_0 - dy/2 = (y0 + dy/2) - dy/2
+    assert gt[5] == -5.0
+
+
+def test_nisar_split_uses_h5py_path(tmp_path):
+    fn = tmp_path / "NISAR_L2_PR_GSLC_001_X_20250101_001.h5"
+    _make_nisar_h5(fn, nx=100, ny=6000, epsg=32637)
+    cfg = DisplacementWorkflow(
+        cslc_file_list=[fn],
+        work_directory=tmp_path,
+        input_options={"subdataset": "/science/LSAR/GSLC/grids/frequencyA/HH"},
+        phase_linking={"half_window": {"y": DEFAULT_HALF_WINDOW_Y, "x": 11}},
+        output_options={"strides": {"y": DEFAULT_STRIDE_Y, "x": 5}},
+    )
+    blocks = split_frame_into_blocks(cfg, num_blocks=3)
+    assert len(blocks) == 3
+    assert all(bb.epsg == 32637 for bb in blocks.values())
+    # Centrals tile, reads overlap
+    centrals = [blocks[f"block_{i:02d}"].central_bounds for i in range(3)]
+    for prev, cur in itertools.pairwise(centrals):
+        assert prev.bottom == cur.top

--- a/tests/test_workflows_block_split.py
+++ b/tests/test_workflows_block_split.py
@@ -230,3 +230,34 @@ def test_nisar_split_uses_h5py_path(tmp_path):
     centrals = [blocks[f"block_{i:02d}"].central_bounds for i in range(3)]
     for prev, cur in itertools.pairwise(centrals):
         assert prev.bottom == cur.top
+
+
+def test_vrtstack_patches_nisar_metadata(tmp_path):
+    """``VRTStack`` must expose real CRS+GT for NISAR.
+
+    Regression test for the all-zero ``bounds_mask`` failure that fired
+    when the azimuth-block splitter set ``output_options.bounds`` on a
+    NISAR run: GDAL's HDF5 driver returns identity geotransform + empty
+    projection, so rasterizing a real-world polygon onto the VRT
+    produced an empty mask and ``masking.MaskingError`` downstream.
+    """
+    from dolphin.io import VRTStack
+
+    fn = tmp_path / "NISAR_L2_PR_GSLC_001_X_20250101_001.h5"
+    _make_nisar_h5(fn, nx=50, ny=100, epsg=32637)
+    vrt = VRTStack(
+        [fn],
+        outfile=tmp_path / "stack.vrt",
+        subdataset="/science/LSAR/GSLC/grids/frequencyA/HH",
+        sort_files=False,
+        skip_size_check=True,
+    )
+    # Patched from h5py — NOT GDAL's identity / empty
+    assert vrt.gt != (0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+    assert vrt.gt[1] == 10.0  # dx
+    assert vrt.gt[5] == -5.0  # dy
+    assert "UTM zone 37N" in vrt.proj
+    # And the .vrt on disk carries the same patched metadata
+    ds = gdal.Open(str(tmp_path / "stack.vrt"))
+    assert ds.GetGeoTransform() == vrt.gt
+    assert "UTM zone 37N" in ds.GetProjection()

--- a/tests/test_workflows_block_split.py
+++ b/tests/test_workflows_block_split.py
@@ -1,0 +1,170 @@
+"""Tests for the NISAR azimuth-block splitter."""
+
+from __future__ import annotations
+
+import dataclasses
+import itertools
+from pathlib import Path
+
+import pytest
+from osgeo import gdal, osr
+
+from dolphin._types import Bbox
+from dolphin.workflows._block_split import (
+    BlockBounds,
+    _min_halo_rows,
+    crop_to_central,
+    split_frame_into_blocks,
+)
+from dolphin.workflows.config import DisplacementWorkflow
+
+gdal.UseExceptions()
+
+
+# Defaults that exercise non-trivial halo math:
+#   max(half_window_y=7, sim_radius=7 * stride_y=3, corr/2=5 * stride_y=3) + 5
+DEFAULT_HALF_WINDOW_Y = 7
+DEFAULT_STRIDE_Y = 3
+EXPECTED_DEFAULT_HALO = 26
+
+
+def _make_geotiff(
+    path: Path,
+    nx: int = 1000,
+    ny: int = 6000,
+    epsg: int | None = 32610,
+    px: float = 30.0,
+    origin_x: float = 500000.0,
+    origin_y: float = 4000000.0,
+) -> None:
+    """Write a minimal complex32 GeoTIFF with the given size and CRS.
+
+    Pass ``epsg=None`` to produce a file with no projection (negative test).
+    """
+    drv = gdal.GetDriverByName("GTiff")
+    ds = drv.Create(str(path), nx, ny, 1, gdal.GDT_CFloat32)
+    ds.SetGeoTransform((origin_x, px, 0.0, origin_y, 0.0, -px))
+    if epsg is not None:
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(epsg)
+        ds.SetProjection(srs.ExportToWkt())
+    ds = None
+
+
+def _make_cfg(
+    cslc_path: Path,
+    work_dir: Path,
+    *,
+    half_window_y: int = DEFAULT_HALF_WINDOW_Y,
+    stride_y: int = DEFAULT_STRIDE_Y,
+) -> DisplacementWorkflow:
+    return DisplacementWorkflow(
+        cslc_file_list=[cslc_path],
+        work_directory=work_dir,
+        phase_linking={"half_window": {"y": half_window_y, "x": 11}},
+        output_options={"strides": {"y": stride_y, "x": 5}},
+    )
+
+
+@pytest.fixture
+def dated_geotiff(tmp_path: Path) -> Path:
+    """A geocoded GeoTIFF with a parseable date in the filename."""
+    fn = tmp_path / "20250101_slc.tif"
+    _make_geotiff(fn)
+    return fn
+
+
+def test_min_halo_uses_max_of_window_sim_corr(tmp_path: Path):
+    fn = tmp_path / "20250101_slc.tif"
+    _make_geotiff(fn)
+    cfg = _make_cfg(fn, tmp_path)
+    # max(half_window_y=7, sim_radius=7 * stride_y=3, corr/2=5 * stride_y=3) + safety=5
+    assert _min_halo_rows(cfg) == EXPECTED_DEFAULT_HALO
+
+
+def test_num_blocks_1_returns_full_frame_no_halo(dated_geotiff, tmp_path):
+    cfg = _make_cfg(dated_geotiff, tmp_path)
+    blocks = split_frame_into_blocks(cfg, num_blocks=1)
+    assert list(blocks.keys()) == ["block_00"]
+    bb = blocks["block_00"]
+    assert bb.read_bounds == bb.central_bounds
+    assert bb.epsg == 32610
+    assert bb.central_bounds == Bbox(
+        500000.0, 4000000.0 - 6000 * 30.0, 500000.0 + 1000 * 30.0, 4000000.0
+    )
+
+
+def test_central_regions_tile_the_frame(dated_geotiff, tmp_path):
+    cfg = _make_cfg(dated_geotiff, tmp_path)
+    blocks = split_frame_into_blocks(cfg, num_blocks=3)
+    centrals = [blocks[f"block_{i:02d}"].central_bounds for i in range(3)]
+    # Adjacent centrals share an edge (no gap, no overlap)
+    for prev, cur in itertools.pairwise(centrals):
+        assert prev.bottom == cur.top
+    # Top of first == top of frame; bottom of last == bottom of frame
+    assert centrals[0].top == 4000000.0
+    assert centrals[-1].bottom == 4000000.0 - 6000 * 30.0
+
+
+def test_read_bounds_overlap_by_halo_on_interior_edges(dated_geotiff, tmp_path):
+    cfg = _make_cfg(dated_geotiff, tmp_path)
+    halo = _min_halo_rows(cfg)
+    blocks = split_frame_into_blocks(cfg, num_blocks=3)
+    centrals = [blocks[f"block_{i:02d}"].central_bounds for i in range(3)]
+    reads = [blocks[f"block_{i:02d}"].read_bounds for i in range(3)]
+    px_y = 30.0
+    # First block: halo only on the bottom (top is at frame edge)
+    assert reads[0].top == centrals[0].top
+    assert reads[0].bottom == centrals[0].bottom - halo * px_y
+    # Middle block: halo on both sides
+    assert reads[1].top == centrals[1].top + halo * px_y
+    assert reads[1].bottom == centrals[1].bottom - halo * px_y
+    # Last block: halo only on the top
+    assert reads[-1].top == centrals[-1].top + halo * px_y
+    assert reads[-1].bottom == centrals[-1].bottom
+
+
+def test_halo_too_large_raises(tmp_path):
+    fn = tmp_path / "20250101_slc.tif"
+    _make_geotiff(fn, ny=50)  # tiny frame
+    cfg = _make_cfg(fn, tmp_path)
+    with pytest.raises(ValueError, match="too large"):
+        split_frame_into_blocks(cfg, num_blocks=10)
+
+
+def test_missing_projection_raises_with_epsg_message(tmp_path):
+    fn = tmp_path / "20250101_slc.tif"
+    _make_geotiff(fn, epsg=None)
+    cfg = _make_cfg(fn, tmp_path)
+    with pytest.raises(RuntimeError, match="EPSG"):
+        split_frame_into_blocks(cfg, num_blocks=2)
+
+
+def test_crop_to_central_replaces_in_place(dated_geotiff, tmp_path):
+    cfg = _make_cfg(dated_geotiff, tmp_path)
+    blocks = split_frame_into_blocks(cfg, num_blocks=3)
+    bb = blocks["block_01"]
+
+    # Copy frame to a sibling, then crop in-place
+    target = tmp_path / "to_crop.tif"
+    gdal.Translate(str(target), str(dated_geotiff))
+    crop_to_central(target, bb.central_bounds)
+
+    ds = gdal.Open(str(target))
+    expected_ny = round((bb.central_bounds.top - bb.central_bounds.bottom) / 30)
+    assert ds.RasterYSize == expected_ny
+    assert ds.RasterXSize == 1000  # x extent unchanged
+    # Same path retained
+    assert target.exists()
+    # No stray .cropped sibling
+    assert not (tmp_path / "to_crop.cropped.tif").exists()
+
+
+def test_block_bounds_dataclass_immutable():
+    bb = BlockBounds(
+        read_bounds=Bbox(0.0, 0.0, 1.0, 1.0),
+        central_bounds=Bbox(0.0, 0.0, 1.0, 1.0),
+        epsg=4326,
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        bb.epsg = 32610  # type: ignore[misc]


### PR DESCRIPTION
Adds a **block-as-burst** pattern so NISAR full-frame GSLCs can be processed in parallel using the existing burst pool.

For burst inputs nothing changes. For NISAR (non-burst) inputs, when `input_options.azimuth_blocks > 1` the frame is split into N azimuth blocks at the dispatch layer, each block is processed as a synthetic burst through `ProcessPoolExecutor`, and per-block outputs are stitched by the existing `stitching_bursts.run` step. No changes to `wrapped_phase.run` or the stitcher are required.

## Change Summary

- `workflows/_block_split.py` _(new)_ — `split_frame_into_blocks()` divides the pixel grid into N azimuth blocks with a halo; `_min_halo_rows()` auto-computes the minimum safe overlap from half-window, similarity search radius, and stride settings.
- `workflows/config/_common.py` — `InputOptions` gains `azimuth_blocks: int = 1` and `halo_rows: Optional[int] = None`.
- `workflows/displacement.py` — extracts dispatch into a testable `_prepare_grouped_inputs()` function; sets `HDF5_USE_FILE_LOCKING=FALSE` before spawning workers when multiple processes share the same HDF5 files (prevents hangs on NFS/Lustre).
- `workflows/_utils.py` — `_create_burst_cfg` accepts an optional `bounds` parameter to set `output_options.bounds` per block.

Typical config for a 4-block run:

```yaml
input_options:
  azimuth_blocks: 4
worker_settings:
  n_parallel_bursts: 4
  threads_per_worker: 2
```

## CLAUDE NOTES
```ProcessPoolExecutor (mp_context="spawn", size = n_parallel_bursts)
└── Process #k (one per active "burst" / NISAR block)
    │
    ├── ThreadPoolExecutor (size = workers_per_burst = n_parallel_bursts // active_bursts)
    │   └── threads doing GDAL/HDF5 read-ahead inside EagerLoader
    │
    └── Main thread: per-output-block phase-linking
        ├── JAX/XLA host pool (default = os.cpu_count())
        │   └── parallelizes vmap'd ops across pixels
        └── BLAS via OMP_NUM_THREADS = threads_per_worker
            └── multi-threads eigh, solve, matmul inside JAX kernels
```
Key insight: n_parallel_bursts is dual-purpose. It's the outer pool size AND a budget that gets re-allocated to inner I/O workers when there are fewer "bursts" than pool slots.

n_parallel_bursts = 8, with N bursts available:
  N = 1 (FULL)    → 1 active process × 8 inner I/O threads
  N = 4           → 4 active processes × 2 inner I/O threads each
  N = 8 (BLOCKED) → 8 active processes × 1 inner I/O thread each

# FULL vs BLOCKED 

| Aspect | FULL (`azimuth_blocks=1`) | BLOCKED (`azimuth_blocks=N`) |
|--------|---------------------------|------------------------------|
| **Processes** | 1 | N (8 typical) |
| **GIL** | Locked to 1 interpreter | Escaped — N interpreters |
| **JAX kernels** | Parallelize across pixels via `vmap` (within 1 block) | Same per block, run N in parallel across blocks |
| **Python control flow** | Strictly serial sweep through frame | N serial sweeps in parallel |
| **HDF5 reads** | 1 stream | N concurrent streams |
| **JIT compile** | Once, ~10–30 s | N times in parallel, ~30 s wall |
| **Working set** | Full frame in 1 process | ~1/N of frame in each process |

Each worker still uses ~1 core; you just have N of them running simultaneously on different rows.

---

# Per-Knob Impact

## `n_parallel_bursts`

- Bigger = more outer pool slots (capped by available bursts)
- For NISAR: this **is** the number of blocks running in parallel
- ~~Set equal to `azimuth_blocks` for maximum block parallelism~~
- **Typical sweet spot:** both at **8**

---

## `threads_per_worker`

Sets `OMP_NUM_THREADS`, `MKL_NUM_THREADS`, but not used well by JAX (multiple issues open on JAX about CPU thread control). Setting to 1 or 2 is usually fine.
JAX’s XLA backend maintains its own thread pool, sized by default to:

```python
os.cpu_count()
```

## Local benchmark full frame vs blocked results

 displacement.run end-to-end through PS+PL+stitch benchmark run with taskset -c 0-33 

  GSLCs               : 7 (Track 042 Frame 070 Descending orbit)
  half_window         : 5
  num_blocks          : 8
  n_parallel_bursts   : 8 (both modes)
  threads_per_worker  : 4 (both modes)
  block_shape: 2048x2048 (both modes)
  active threads FULL : 4
  active threads BLK  : 32

  FULL     wall =   8387.3s  (139.79 min)
  BLOCKED  wall =   2159.2s  ( 35.99 min)
   SPEEDUP (BLOCKED vs FULL) : 3.88×



## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review
