### PR TITLE
Remove outdated `single-reference` doc from `InterferogramNetwork`

### DIFF
--- a/src/dolphin/workflows/config/_common.py
+++ b/src/dolphin/workflows/config/_common.py
@@ -171,10 +171,7 @@ class PhaseLinkingOptions(BaseModel, extra="forbid"):
 
 
 class InterferogramNetwork(BaseModel, extra="forbid"):
-    """Options to determine the type of network for interferogram formation.
-
-    If no parameters passed, uses single-reference network with `reference_idx=0`.
-    """
+    """Options to determine the type of network for interferogram formation."""
 
     _directory: Path = PrivateAttr(Path("interferograms"))
 


### PR DESCRIPTION
Single reference used to be default, now for Displacement workflow it is nearest-3: https://github.com/isce-framework/dolphin/blob/main/src/dolphin/workflows/config/_displacement.py#L138-L150