### PR TITLE
fix(utils): correct nomask check in take_looks

### DIFF
--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -223,7 +223,7 @@ def take_looks(arr, row_looks, col_looks, func_type="nansum", edge_strategy="cut
             func_type=func_type,
             edge_strategy=edge_strategy,
         )
-        if arr.mask.ndim == np.ma.nomask:
+        if arr.mask is np.ma.nomask:
             looked_mask = arr.mask
         else:
             looked_mask = take_looks(


### PR DESCRIPTION
## Summary

`take_looks` guarded its masked-input branch with
`arr.mask.ndim == np.ma.nomask`, which compares an integer (`ndim`) against the
`nomask` sentinel (`np.False_`). That comparison is essentially always `False`,
so the intended "no mask present" shortcut never triggered.

## Change

Use the correct identity check: `arr.mask is np.ma.nomask`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)