### PR TITLE
Add Gaussian multilooking option for phase linking

### DIFF
--- a/src/dolphin/phase_link/_core.py
+++ b/src/dolphin/phase_link/_core.py
@@ -49,7 +49,12 @@ class PhaseLinkOutput(NamedTuple):
     """
 
     shp_counts: np.ndarray
-    """Number of neighbor pixels used in adaptive multilooking."""
+    """Number of effective looks used in multilooking.
+
+    For boolean SHP methods (GLRT, KS), this is the count of neighbor pixels.
+    For float weights (Gaussian), this is the effective number of looks (ENL)
+    via Kish's formula: ENL = (sum(w))^2 / sum(w^2).
+    """
 
     eigenvalues: np.ndarray
     """The smallest (largest) eigenvalue resulting from EMI (EVD)."""
@@ -362,8 +367,14 @@ def run_cpl(
     # Get the SHP counts for each pixel (if not using Rect window)
     if neighbor_arrays is None:
         shp_counts = jnp.zeros(temp_coh.shape, dtype=np.int16)
-    else:
+    elif neighbor_arrays.dtype == np.bool_:
         shp_counts = jnp.sum(neighbor_arrays, axis=(-2, -1))
+    else:
+        # For float weights (e.g. Gaussian), compute effective number of looks
+        # ENL = (sum(w))^2 / sum(w^2)  (Kish, 1965, Survey Sampling)
+        w_sum = jnp.sum(neighbor_arrays, axis=(-2, -1))
+        w_sq_sum = jnp.sum(neighbor_arrays**2, axis=(-2, -1))
+        shp_counts = jnp.round(w_sum**2 / w_sq_sum).astype(jnp.int16)
 
     return PhaseLinkOutput(
         cpx_phase=cpx_phase_reshaped,

--- a/src/dolphin/phase_link/covariance.py
+++ b/src/dolphin/phase_link/covariance.py
@@ -129,6 +129,7 @@ def coh_mat_single(
     -------
     Array
         Coherence matrix with shape (n_slc, n_slc).
+
     """
     _nslc, nsamps = slc_samples.shape
 

--- a/src/dolphin/shp/_gaussian.py
+++ b/src/dolphin/shp/_gaussian.py
@@ -1,0 +1,80 @@
+"""Gaussian weighting for multilooking."""
+
+from __future__ import annotations
+
+from functools import partial
+
+import jax.numpy as jnp
+from jax import Array, jit
+
+from dolphin.utils import compute_out_shape
+
+
+@partial(
+    jit,
+    static_argnames=["halfwin_rowcol", "strides", "input_shape"],
+)
+def estimate_neighbors(
+    halfwin_rowcol: tuple[int, int],
+    input_shape: tuple[int, int],
+    strides: tuple[int, int] = (1, 1),
+) -> Array:
+    """Generate Gaussian weights for multilooking.
+
+    Unlike GLRT or KS methods, Gaussian multilooking uses a fixed weight
+    pattern (same for all pixels) based on a 2D Gaussian window.
+
+    Parameters
+    ----------
+    halfwin_rowcol : tuple[int, int]
+        Half the size of the window in (row, col) dimensions.
+    input_shape : tuple[int, int]
+        Shape of the input image (rows, cols).
+    strides : tuple[int, int]
+        The (row, col) strides to use for the sliding window.
+        By default (1, 1), meaning output size equals input size.
+
+    Returns
+    -------
+    weights : Array, 4D
+        Float array of Gaussian weights for each pixel in the window.
+        Shape is (out_rows, out_cols, window_rows, window_cols).
+        Weights are normalized so they sum to 1 (excluding the center pixel).
+
+    """
+    rows, cols = input_shape
+    half_row, half_col = halfwin_rowcol
+
+    out_rows, out_cols = compute_out_shape((rows, cols), strides)
+
+    window_rsize = 2 * half_row + 1
+    window_csize = 2 * half_col + 1
+
+    # Create a 2D Gaussian window
+    # Use sigma = half_window / 2 so that the window covers ~2 sigma
+    sigma_row = half_row / 2.0 if half_row > 0 else 0.5
+    sigma_col = half_col / 2.0 if half_col > 0 else 0.5
+
+    # Create coordinate grids centered at 0
+    row_coords = jnp.arange(window_rsize) - half_row
+    col_coords = jnp.arange(window_csize) - half_col
+
+    # Compute 2D Gaussian: exp(-(r^2/(2*sr^2) + c^2/(2*sc^2)))
+    row_gauss = jnp.exp(-0.5 * (row_coords / sigma_row) ** 2)
+    col_gauss = jnp.exp(-0.5 * (col_coords / sigma_col) ** 2)
+    gaussian_window = jnp.outer(row_gauss, col_gauss)
+
+    # Set center pixel to 0 (don't include self in weighting, matching GLRT behavior)
+    gaussian_window = gaussian_window.at[half_row, half_col].set(0.0)
+
+    # Normalize so weights sum to 1
+    gaussian_window = gaussian_window / jnp.sum(gaussian_window)
+
+    # Broadcast to all output pixels (same weights for each pixel)
+    # Shape: (out_rows, out_cols, window_rows, window_cols)
+    weights = jnp.broadcast_to(
+        gaussian_window[None, None, :, :],
+        (out_rows, out_cols, window_rsize, window_csize),
+    )
+
+    return weights

--- a/src/dolphin/workflows/config/_enums.py
+++ b/src/dolphin/workflows/config/_enums.py
@@ -12,6 +12,7 @@ class ShpMethod(str, Enum):
     GLRT = "glrt"
     KS = "ks"
     RECT = "rect"
+    GAUSSIAN = "gaussian"
     # Alias for no SHP search
     NONE = "rect"
 

--- a/tests/test_phase_link_covariance.py
+++ b/tests/test_phase_link_covariance.py
@@ -156,7 +156,7 @@ def test_estimate_stack_covariance_neighbors_masked(slcs):
 
 def test_coh_mat_single_float_weights(slcs):
     """Test that float weights work correctly for Gaussian multilooking."""
-    num_slc, rows, cols = slcs.shape
+    num_slc, _rows, cols = slcs.shape
     slc_samples = slcs.reshape(num_slc, -1)
     nsamps = slc_samples.shape[1]
 
@@ -210,7 +210,10 @@ def test_estimate_stack_covariance_gaussian_weights():
 
     # Compute covariance with Gaussian weights
     C_gaussian = covariance.estimate_stack_covariance(
-        slc_stack, half_window=half_window, strides=strides, neighbor_arrays=gaussian_weights
+        slc_stack,
+        half_window=half_window,
+        strides=strides,
+        neighbor_arrays=gaussian_weights,
     )
 
     # Check output shape


### PR DESCRIPTION
## Summary

Adds a `GAUSSIAN` SHP method: a fixed 2D Gaussian window for weighting neighbors
during coherence estimation, as a simpler alternative to the adaptive GLRT/KS
tests. Unlike the adaptive methods, it applies the same weight pattern to every
pixel.

## Changes

- Add `ShpMethod.GAUSSIAN` enum value.
- New `shp/_gaussian.py` generating Gaussian weights (JAX).
- `shp/__init__.py` dispatcher handles the `GAUSSIAN` method.
- `covariance.coh_mat_single` accepts both boolean masks (GLRT/KS) and float
  weights (Gaussian) via unified float handling.
- `shp_counts` now reports the effective number of looks (ENL) for float-weight
  methods via Kish's formula `ENL = (sum w)^2 / sum(w^2)`, instead of a raw
  neighbor count (which is only meaningful for boolean SHP).

## Tests

New tests in `test_shp.py`, `test_phase_link_covariance.py`,
`test_phase_link_core.py` covering Gaussian weight generation and comparison
with RECT/boolean methods. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)